### PR TITLE
Default implementation for StorIODb execSql(), get(), put(), delete()

### DIFF
--- a/storio/src/main/java/com/pushtorefresh/storio/db/StorIODb.java
+++ b/storio/src/main/java/com/pushtorefresh/storio/db/StorIODb.java
@@ -34,7 +34,9 @@ public abstract class StorIODb {
      *
      * @return builder for PreparedExecSql
      */
-    @NonNull public abstract PreparedExecSql.Builder execSql();
+    @NonNull public PreparedExecSql.Builder execSql() {
+        return new PreparedExecSql.Builder(this);
+    }
 
     /**
      * Prepares "get" operation for {@link StorIODb}
@@ -42,7 +44,9 @@ public abstract class StorIODb {
      *
      * @return builder for PreparedGet
      */
-    @NonNull public abstract PreparedGet.Builder get();
+    @NonNull public PreparedGet.Builder get() {
+        return new PreparedGet.Builder(this);
+    }
 
     /**
      * Prepares "put" operation for {@link StorIODb}
@@ -50,7 +54,9 @@ public abstract class StorIODb {
      *
      * @return builder for PreparedPut
      */
-    @NonNull public abstract PreparedPut.Builder put();
+    @NonNull public PreparedPut.Builder put() {
+        return new PreparedPut.Builder(this);
+    }
 
     /**
      * Prepares "delete" operation for {@link StorIODb}
@@ -58,7 +64,9 @@ public abstract class StorIODb {
      *
      * @return builder for PreparedDelete
      */
-    @NonNull public abstract PreparedDelete.Builder delete();
+    @NonNull public PreparedDelete.Builder delete() {
+        return new PreparedDelete.Builder(this);
+    }
 
     /**
      * Subscribes to changes in required tables
@@ -152,11 +160,11 @@ public abstract class StorIODb {
         public abstract void notifyAboutChanges(@NonNull Changes changes);
 
         /**
-         * {@link StorIODb} implementation could not provide support for transactions
+         * Returns true if {@link StorIODb} implementation supports transactions
          *
          * @return true if transactions are supported, false otherwise
          */
-        public abstract boolean areTransactionsSupported();
+        public abstract boolean transactionsSupported();
 
         /**
          * Begins a transaction in EXCLUSIVE mode

--- a/storio/src/main/java/com/pushtorefresh/storio/db/impl/StorIOSQLiteDb.java
+++ b/storio/src/main/java/com/pushtorefresh/storio/db/impl/StorIOSQLiteDb.java
@@ -141,7 +141,7 @@ public class StorIOSQLiteDb extends StorIODb {
             changesBus.onNext(changes);
         }
 
-        @Override public boolean areTransactionsSupported() {
+        @Override public boolean transactionsSupported() {
             return true;
         }
 

--- a/storio/src/main/java/com/pushtorefresh/storio/db/impl/StorIOSQLiteDb.java
+++ b/storio/src/main/java/com/pushtorefresh/storio/db/impl/StorIOSQLiteDb.java
@@ -8,10 +8,6 @@ import android.support.annotation.NonNull;
 
 import com.pushtorefresh.storio.db.StorIODb;
 import com.pushtorefresh.storio.db.operation.Changes;
-import com.pushtorefresh.storio.db.operation.delete.PreparedDelete;
-import com.pushtorefresh.storio.db.operation.exec_sql.PreparedExecSql;
-import com.pushtorefresh.storio.db.operation.get.PreparedGet;
-import com.pushtorefresh.storio.db.operation.put.PreparedPut;
 import com.pushtorefresh.storio.db.query.DeleteQuery;
 import com.pushtorefresh.storio.db.query.InsertQuery;
 import com.pushtorefresh.storio.db.query.Query;
@@ -44,22 +40,6 @@ public class StorIOSQLiteDb extends StorIODb {
 
     protected StorIOSQLiteDb(@NonNull SQLiteDatabase db) {
         this.db = db;
-    }
-
-    @NonNull @Override public PreparedExecSql.Builder execSql() {
-        return new PreparedExecSql.Builder(this);
-    }
-
-    @NonNull @Override public PreparedGet.Builder get() {
-        return new PreparedGet.Builder(this);
-    }
-
-    @NonNull @Override public PreparedPut.Builder put() {
-        return new PreparedPut.Builder(this);
-    }
-
-    @NonNull @Override public PreparedDelete.Builder delete() {
-        return new PreparedDelete.Builder(this);
     }
 
     @Override @NonNull

--- a/storio/src/main/java/com/pushtorefresh/storio/db/operation/delete/PreparedDeleteCollectionOfObjects.java
+++ b/storio/src/main/java/com/pushtorefresh/storio/db/operation/delete/PreparedDeleteCollectionOfObjects.java
@@ -35,7 +35,7 @@ public class PreparedDeleteCollectionOfObjects<T> extends PreparedDelete<DeleteC
 
         final Map<T, DeleteResult> results = new HashMap<>();
 
-        final boolean withTransaction = useTransactionIfPossible && internal.areTransactionsSupported();
+        final boolean withTransaction = useTransactionIfPossible && internal.transactionsSupported();
 
         if (withTransaction) {
             internal.beginTransaction();

--- a/storio/src/main/java/com/pushtorefresh/storio/db/operation/put/PreparedPutIterableContentValues.java
+++ b/storio/src/main/java/com/pushtorefresh/storio/db/operation/put/PreparedPutIterableContentValues.java
@@ -35,7 +35,7 @@ public class PreparedPutIterableContentValues extends PreparedPut<ContentValues,
         final Map<ContentValues, PutResult> putResults = new HashMap<>();
 
         final boolean withTransaction = useTransactionIfPossible
-                && internal.areTransactionsSupported();
+                && internal.transactionsSupported();
 
         if (withTransaction) {
             internal.beginTransaction();

--- a/storio/src/main/java/com/pushtorefresh/storio/db/operation/put/PreparedPutObjects.java
+++ b/storio/src/main/java/com/pushtorefresh/storio/db/operation/put/PreparedPutObjects.java
@@ -36,7 +36,7 @@ public class PreparedPutObjects<T> extends PreparedPut<T, PutCollectionResult<T>
         final Map<T, PutResult> putResults = new HashMap<>();
 
         final boolean withTransaction = useTransactionIfPossible
-                && storIODb.internal().areTransactionsSupported();
+                && storIODb.internal().transactionsSupported();
 
         if (withTransaction) {
             internal.beginTransaction();

--- a/storio/src/test/java/com/pushtorefresh/storio/db/unit_test/design/DesignTestStorIOImpl.java
+++ b/storio/src/test/java/com/pushtorefresh/storio/db/unit_test/design/DesignTestStorIOImpl.java
@@ -61,7 +61,7 @@ public class DesignTestStorIOImpl extends StorIODb {
             // no impl
         }
 
-        @Override public boolean areTransactionsSupported() {
+        @Override public boolean transactionsSupported() {
             return false;
         }
 

--- a/storio/src/test/java/com/pushtorefresh/storio/db/unit_test/operation/PreparedPutTest.java
+++ b/storio/src/test/java/com/pushtorefresh/storio/db/unit_test/operation/PreparedPutTest.java
@@ -128,7 +128,7 @@ public class PreparedPutTest {
             storIODb = mock(StorIODb.class);
             internal = mock(StorIODb.Internal.class);
 
-            when(internal.areTransactionsSupported())
+            when(internal.transactionsSupported())
                     .thenReturn(useTransaction);
 
             when(storIODb.internal())

--- a/storio/src/test/java/com/pushtorefresh/storio/db/unit_test/operation/delete/PreparedDeleteTest.java
+++ b/storio/src/test/java/com/pushtorefresh/storio/db/unit_test/operation/delete/PreparedDeleteTest.java
@@ -135,7 +135,7 @@ public class PreparedDeleteTest {
             mapFunc = (MapFunc<User, DeleteQuery>) mock(MapFunc.class);
             deleteResolver = mock(DeleteResolver.class);
 
-            when(internal.areTransactionsSupported())
+            when(internal.transactionsSupported())
                     .thenReturn(useTransaction);
 
             when(storIODb.internal())


### PR DESCRIPTION
And `StorIODb.Internal#areTransactionsSupported()` was renamed to `transactionsSupported()`

Closes #112 

@nikitin-da PTAL