### PR TITLE
Don't throw exception from notifyAboutChanges() if RxJava is not available

### DIFF
--- a/storio/src/main/java/com/pushtorefresh/storio/db/impl/StorIOSQLiteDb.java
+++ b/storio/src/main/java/com/pushtorefresh/storio/db/impl/StorIOSQLiteDb.java
@@ -127,11 +127,10 @@ public class StorIOSQLiteDb extends StorIODb {
         }
 
         @Override public void notifyAboutChanges(@NonNull Changes changes) {
-            if (changesBus == null) {
-                throw EnvironmentUtil.newRxJavaIsNotAvailableException("Notifying about changes in StorIODb");
+            // Notifying about changes requires RxJava, if RxJava is not available -> skip notification
+            if (changesBus != null) {
+                changesBus.onNext(changes);
             }
-
-            changesBus.onNext(changes);
         }
 
         @Override public boolean transactionsSupported() {


### PR DESCRIPTION
Allows to use `StorIODb` without `RxJava` and modify tables.

Case:
1. No `RxJava`
2. User making change in `StorIODb` and Operation tries to call `StorIODb.Internal#notifyAboutChanges()`
3. Crash with "RxJava is not available` exception

Now notifying about changes won't require `RxJava`, but observing changes will.

@nikitin-da PTAL