### PR TITLE
Add GetResolver test for StorIOContentProvider, improve test for StorIODb

### DIFF
--- a/storio/src/test/java/com/pushtorefresh/storio/contentprovider/operation/get/DefaultGetResolverTest.java
+++ b/storio/src/test/java/com/pushtorefresh/storio/contentprovider/operation/get/DefaultGetResolverTest.java
@@ -1,0 +1,44 @@
+package com.pushtorefresh.storio.contentprovider.operation.get;
+
+import android.database.Cursor;
+
+import com.pushtorefresh.storio.contentprovider.StorIOContentProvider;
+import com.pushtorefresh.storio.contentprovider.query.Query;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DefaultGetResolverTest {
+
+    @Test
+    public void query() {
+        final StorIOContentProvider storIOContentProvider = mock(StorIOContentProvider.class);
+        final StorIOContentProvider.Internal internal = mock(StorIOContentProvider.Internal.class);
+        final Query query = mock(Query.class);
+        final Cursor expectedCursor = mock(Cursor.class);
+
+        when(storIOContentProvider.internal())
+                .thenReturn(internal);
+
+        when(internal.query(query))
+                .thenReturn(expectedCursor);
+
+        final DefaultGetResolver defaultGetResolver = new DefaultGetResolver();
+
+        final Cursor actualCursor = defaultGetResolver.performGet(storIOContentProvider, query);
+
+        // only one request should occur
+        verify(internal, times(1)).query(any(Query.class));
+
+        // and this request should be equals to original
+        verify(internal, times(1)).query(query);
+
+        assertSame(expectedCursor, actualCursor);
+    }
+}

--- a/storio/src/test/java/com/pushtorefresh/storio/db/operation/get/DefaultGetResolverTest.java
+++ b/storio/src/test/java/com/pushtorefresh/storio/db/operation/get/DefaultGetResolverTest.java
@@ -1,11 +1,14 @@
 package com.pushtorefresh.storio.db.operation.get;
 
+import android.database.Cursor;
+
 import com.pushtorefresh.storio.db.StorIODb;
 import com.pushtorefresh.storio.db.query.Query;
 import com.pushtorefresh.storio.db.query.RawQuery;
 
 import org.junit.Test;
 
+import static junit.framework.Assert.assertSame;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -14,41 +17,55 @@ import static org.mockito.Mockito.when;
 
 public class DefaultGetResolverTest {
 
-    @Test public void rawQuery() {
+    @Test
+    public void rawQuery() {
         final StorIODb storIODb = mock(StorIODb.class);
         final StorIODb.Internal internal = mock(StorIODb.Internal.class);
+        final RawQuery rawQuery = mock(RawQuery.class);
+        final Cursor expectedCursor = mock(Cursor.class);
 
         when(storIODb.internal())
                 .thenReturn(internal);
 
-        final DefaultGetResolver defaultGetResolver = new DefaultGetResolver();
-        final RawQuery rawQuery = mock(RawQuery.class);
+        when(internal.rawQuery(rawQuery))
+                .thenReturn(expectedCursor);
 
-        defaultGetResolver.performGet(storIODb, rawQuery);
+        final DefaultGetResolver defaultGetResolver = new DefaultGetResolver();
+
+        final Cursor actualCursor = defaultGetResolver.performGet(storIODb, rawQuery);
 
         // only one request should occur
         verify(internal, times(1)).rawQuery(any(RawQuery.class));
 
         // and this request should be equals to original
         verify(internal, times(1)).rawQuery(rawQuery);
+
+        assertSame(expectedCursor, actualCursor);
     }
 
-    @Test public void query() {
+    @Test
+    public void query() {
         final StorIODb storIODb = mock(StorIODb.class);
         final StorIODb.Internal internal = mock(StorIODb.Internal.class);
+        final Query query = mock(Query.class);
+        final Cursor expectedCursor = mock(Cursor.class);
 
         when(storIODb.internal())
                 .thenReturn(internal);
 
-        final DefaultGetResolver defaultGetResolver = new DefaultGetResolver();
-        final Query query = mock(Query.class);
+        when(internal.query(query))
+                .thenReturn(expectedCursor);
 
-        defaultGetResolver.performGet(storIODb, query);
+        final DefaultGetResolver defaultGetResolver = new DefaultGetResolver();
+
+        final Cursor actualCursor = defaultGetResolver.performGet(storIODb, query);
 
         // only one request should occur
         verify(internal, times(1)).query(any(Query.class));
 
         // and this request should be equals to original
         verify(internal, times(1)).query(query);
+
+        assertSame(expectedCursor, actualCursor);
     }
 }


### PR DESCRIPTION
Added test for `GetResolver` of `StorIOContentProvider`

Improved test for `GetResolver` of `StorIODb`, now it checks the result of performed operation.

@nikitin-da please take a look