### PR TITLE
Remove ContentValues argument from DefaultPutResolver.getIdColumnName()

### DIFF
--- a/storio-contentprovider/src/main/java/com/pushtorefresh/storio/contentprovider/operation/put/DefaultPutResolver.java
+++ b/storio-contentprovider/src/main/java/com/pushtorefresh/storio/contentprovider/operation/put/DefaultPutResolver.java
@@ -32,7 +32,7 @@ public abstract class DefaultPutResolver<T> implements PutResolver<T> {
      * @return column name to store internal id.
      */
     @NonNull
-    protected String getIdColumnName(@NonNull ContentValues contentValues) {
+    protected String getIdColumnName() {
         return BaseColumns._ID;
     }
 
@@ -51,7 +51,7 @@ public abstract class DefaultPutResolver<T> implements PutResolver<T> {
     @Override
     public PutResult performPut(@NonNull StorIOContentProvider storIOContentProvider, @NonNull ContentValues contentValues) {
         final Uri uri = getUri(contentValues);
-        final String idColumnName = getIdColumnName(contentValues);
+        final String idColumnName = getIdColumnName();
 
         final Object idObject = contentValues.get(idColumnName);
         final String idAsString = idObject != null ? idObject.toString() : null;

--- a/storio-contentprovider/src/test/java/com/pushtorefresh/storio/contentprovider/operation/put/DefaultPutResolverTest.java
+++ b/storio-contentprovider/src/test/java/com/pushtorefresh/storio/contentprovider/operation/put/DefaultPutResolverTest.java
@@ -87,7 +87,7 @@ public class DefaultPutResolverTest {
         final PutResolver<TestItem> putResolver = new DefaultPutResolver<TestItem>() {
             @NonNull
             @Override
-            protected String getIdColumnName(@NonNull ContentValues contentValues) {
+            protected String getIdColumnName() {
                 return TestItem.COLUMN_ID;
             }
 
@@ -151,7 +151,7 @@ public class DefaultPutResolverTest {
         final PutResolver<TestItem> putResolver = new DefaultPutResolver<TestItem>() {
             @NonNull
             @Override
-            protected String getIdColumnName(@NonNull ContentValues contentValues) {
+            protected String getIdColumnName() {
                 return TestItem.COLUMN_ID;
             }
 
@@ -221,7 +221,7 @@ public class DefaultPutResolverTest {
         final PutResolver<TestItem> putResolver = new DefaultPutResolver<TestItem>() {
             @NonNull
             @Override
-            protected String getIdColumnName(@NonNull ContentValues contentValues) {
+            protected String getIdColumnName() {
                 return TestItem.COLUMN_ID;
             }
 


### PR DESCRIPTION
Closes #178 

I decided to remove `ContentValues` param from `DefaultPutResolver.getIdColumnName()` for simplicity and better performance (no unneeded parameter passing).

In 99% of cases users won't use `ContentValues` to resolve `idColumnName`, it's a work for frameworks and libs based on `StorIO`, so we can keep simpler API for most of our users :)

@nikitin-da PTAL