### PR TITLE
StorIOSQLite Get Operation does not require RxJava in ClassPath

### DIFF
--- a/storio-common/src/main/java/com/pushtorefresh/storio/operation/internal/MapSomethingToExecuteAsBlocking.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio/operation/internal/MapSomethingToExecuteAsBlocking.java
@@ -1,0 +1,41 @@
+package com.pushtorefresh.storio.operation.internal;
+
+import android.support.annotation.NonNull;
+
+import com.pushtorefresh.storio.operation.PreparedOperation;
+
+import rx.functions.Func1;
+
+/**
+ * Required to avoid problems with ClassLoader when RxJava is not in ClassPath
+ * We can not use anonymous classes from RxJava directly in StorIO, ClassLoader won't be happy :(
+ * <p>
+ * For internal usage only!
+ */
+public class MapSomethingToExecuteAsBlocking<Something, Result> implements Func1<Something, Result> {
+
+    @NonNull
+    private final PreparedOperation<Result> preparedOperation;
+
+    private MapSomethingToExecuteAsBlocking(@NonNull PreparedOperation<Result> preparedOperation) {
+        this.preparedOperation = preparedOperation;
+    }
+
+    /**
+     * Creates new instance of {@link MapSomethingToExecuteAsBlocking}
+     *
+     * @param preparedOperation non-null instance of {@link PreparedOperation} which will be used to react on calls to rx function
+     * @param <Something>       type of map argument
+     * @param <Result>          type of result of rx map function
+     * @return new instance of {@link MapSomethingToExecuteAsBlocking}
+     */
+    @NonNull
+    public static <Something, Result> Func1<Something, Result> newInstance(@NonNull PreparedOperation<Result> preparedOperation) {
+        return new MapSomethingToExecuteAsBlocking<Something, Result>(preparedOperation);
+    }
+
+    @Override
+    public Result call(Something changes) {
+        return preparedOperation.executeAsBlocking();
+    }
+}

--- a/storio-common/src/main/java/com/pushtorefresh/storio/operation/internal/OnSubscribeExecuteAsBlocking.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio/operation/internal/OnSubscribeExecuteAsBlocking.java
@@ -1,0 +1,44 @@
+package com.pushtorefresh.storio.operation.internal;
+
+import android.support.annotation.NonNull;
+
+import com.pushtorefresh.storio.operation.PreparedOperation;
+
+import rx.Observable;
+import rx.Subscriber;
+
+/**
+ * Required to avoid problems with ClassLoader when RxJava is not in ClassPath
+ * We can not use anonymous classes from RxJava directly in StorIO, ClassLoader won't be happy :(
+ * <p>
+ * For internal usage only!
+ */
+public class OnSubscribeExecuteAsBlocking<Result> implements Observable.OnSubscribe<Result> {
+
+    @NonNull
+    private final PreparedOperation<Result> preparedOperation;
+
+    private OnSubscribeExecuteAsBlocking(@NonNull PreparedOperation<Result> preparedOperation) {
+        this.preparedOperation = preparedOperation;
+    }
+
+    /**
+     * Creates new instance of {@link OnSubscribeExecuteAsBlocking}
+     *
+     * @param preparedOperation non-null instance of {@link PreparedOperation} which will be used to provide result to subscribers
+     * @param <Result> type of result of {@link PreparedOperation}
+     * @return new instance of {@link OnSubscribeExecuteAsBlocking}
+     */
+    @NonNull
+    public static <Result> Observable.OnSubscribe<Result> newInstance(@NonNull PreparedOperation<Result> preparedOperation) {
+        return new OnSubscribeExecuteAsBlocking<Result>(preparedOperation);
+    }
+
+    @Override
+    public void call(Subscriber<? super Result> subscriber) {
+        if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(preparedOperation.executeAsBlocking());
+            subscriber.onCompleted();
+        }
+    }
+}

--- a/storio-common/src/test/java/com/pushtorefresh/storio/operation/internal/MapSomethingToExecuteAsBlockingTest.java
+++ b/storio-common/src/test/java/com/pushtorefresh/storio/operation/internal/MapSomethingToExecuteAsBlockingTest.java
@@ -1,0 +1,37 @@
+package com.pushtorefresh.storio.operation.internal;
+
+import com.pushtorefresh.storio.operation.PreparedOperation;
+
+import org.junit.Test;
+
+import rx.Observable;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MapSomethingToExecuteAsBlockingTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void verifyBehavior() {
+        final PreparedOperation<String> preparedOperation = mock(PreparedOperation.class);
+
+        final String expectedMapResult = "expected_string";
+
+        when(preparedOperation.executeAsBlocking())
+                .thenReturn(expectedMapResult);
+
+        final String actualMapResult = Observable.just(1)
+                .map(MapSomethingToExecuteAsBlocking.newInstance(preparedOperation))
+                .toBlocking()
+                .first();
+
+        verify(preparedOperation, times(1)).executeAsBlocking();
+        verify(preparedOperation, times(0)).createObservable();
+
+        assertEquals(expectedMapResult, actualMapResult);
+    }
+}

--- a/storio-common/src/test/java/com/pushtorefresh/storio/operation/internal/OnSubscribeExecuteAsBlockingTest.java
+++ b/storio-common/src/test/java/com/pushtorefresh/storio/operation/internal/OnSubscribeExecuteAsBlockingTest.java
@@ -1,0 +1,36 @@
+package com.pushtorefresh.storio.operation.internal;
+
+import com.pushtorefresh.storio.operation.PreparedOperation;
+
+import org.junit.Test;
+
+import rx.Observable;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class OnSubscribeExecuteAsBlockingTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void verifyBehavior() {
+        final PreparedOperation<String> preparedOperation = mock(PreparedOperation.class);
+
+        final String expectedResult = "expected_string";
+
+        when(preparedOperation.executeAsBlocking())
+                .thenReturn(expectedResult);
+
+        final String actualResult = Observable.create(OnSubscribeExecuteAsBlocking.newInstance(preparedOperation))
+                .toBlocking()
+                .first();
+
+        verify(preparedOperation, times(1)).executeAsBlocking();
+        verify(preparedOperation, times(0)).createObservable();
+
+        assertEquals(expectedResult, actualResult);
+    }
+}

--- a/storio-test-without-rxjava/src/test/java/com/pushtorefresh/storio/test_without_rxjava/sqlite/DefaultStorIOSQLiteTest.java
+++ b/storio-test-without-rxjava/src/test/java/com/pushtorefresh/storio/test_without_rxjava/sqlite/DefaultStorIOSQLiteTest.java
@@ -2,7 +2,10 @@ package com.pushtorefresh.storio.test_without_rxjava.sqlite;
 
 import android.database.sqlite.SQLiteDatabase;
 
+import com.pushtorefresh.storio.operation.MapFunc;
 import com.pushtorefresh.storio.sqlite.impl.DefaultStorIOSQLite;
+import com.pushtorefresh.storio.sqlite.operation.get.GetResolver;
+import com.pushtorefresh.storio.sqlite.query.Query;
 
 import org.junit.Test;
 
@@ -16,5 +19,31 @@ public class DefaultStorIOSQLiteTest {
         new DefaultStorIOSQLite.Builder()
                 .db(mock(SQLiteDatabase.class))
                 .build();
+    }
+
+    @Test
+    public void instantiateGetCursor() {
+        new DefaultStorIOSQLite.Builder()
+                .db(mock(SQLiteDatabase.class))
+                .build()
+                .get()
+                .cursor()
+                .withGetResolver(mock(GetResolver.class))
+                .withQuery(mock(Query.class))
+                .prepare();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void instantiateGetListOfObjects() {
+        new DefaultStorIOSQLite.Builder()
+                .db(mock(SQLiteDatabase.class))
+                .build()
+                .get()
+                .listOfObjects(Object.class)
+                .withGetResolver(mock(GetResolver.class))
+                .withMapFunc(mock(MapFunc.class))
+                .withQuery(mock(Query.class))
+                .prepare();
     }
 }


### PR DESCRIPTION
Part of #114

Now user can actually use `StorIOSQLite.get()` without `RxJava`, fixed `ClassLoader` errors via separate classes that hides `RxJava's` classes

@nikitin-da PTAL