### PR TITLE
Add SQLiteTypeDefault, allow default object mapping and Operations over type

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -56,7 +56,7 @@
         <module name="ParenPad"/>
         <module name="TypecastParenPad"/>
         <module name="WhitespaceAfter"/>
-        <module name="WhitespaceAround"/>
+        <!--<module name="WhitespaceAround"/>-->
         <!-- Modifier Checks                                    -->
         <!-- See http://checkstyle.sf.net/config_modifiers.html -->
         <!--module name="ModifierOrder"/-->

--- a/storio-sample-app/src/main/java/com/pushtorefresh/storio/sample/db/DbModule.java
+++ b/storio-sample-app/src/main/java/com/pushtorefresh/storio/sample/db/DbModule.java
@@ -5,6 +5,8 @@ import android.database.sqlite.SQLiteDatabase;
 import android.support.annotation.NonNull;
 
 import com.pushtorefresh.storio.sample.Logger;
+import com.pushtorefresh.storio.sample.db.entity.Tweet;
+import com.pushtorefresh.storio.sqlite.SQLiteTypeDefaults;
 import com.pushtorefresh.storio.sqlite.StorIOSQLite;
 import com.pushtorefresh.storio.sqlite.impl.DefaultStorIOSQLite;
 
@@ -22,6 +24,12 @@ public class DbModule {
     public StorIOSQLite provideStorIOSQLite(@NonNull SQLiteDatabase db) {
         return new DefaultStorIOSQLite.Builder()
                 .db(db)
+                .addDefaultsForType(Tweet.class, new SQLiteTypeDefaults.Builder<Tweet>()
+                        .mappingToContentValues(Tweet.MAP_TO_CONTENT_VALUES)
+                        .mappingFromCursor(Tweet.MAP_FROM_CURSOR)
+                        .putResolver(Tweet.PUT_RESOLVER)
+                        .mappingToDeleteQuery(Tweet.MAP_TO_DELETE_QUERY)
+                        .build())
                 .build()
                 .setLogListener(new Logger());
     }

--- a/storio-sample-app/src/main/java/com/pushtorefresh/storio/sample/db/entity/Tweet.java
+++ b/storio-sample-app/src/main/java/com/pushtorefresh/storio/sample/db/entity/Tweet.java
@@ -10,6 +10,7 @@ import com.pushtorefresh.storio.operation.MapFunc;
 import com.pushtorefresh.storio.sqlite.operation.put.DefaultPutResolver;
 import com.pushtorefresh.storio.sqlite.operation.put.PutResolver;
 import com.pushtorefresh.storio.sqlite.operation.put.PutResult;
+import com.pushtorefresh.storio.sqlite.query.DeleteQuery;
 import com.pushtorefresh.storio.sqlite.query.Query;
 
 /**
@@ -33,7 +34,8 @@ public class Tweet {
 
     public static final MapFunc<Cursor, Tweet> MAP_FROM_CURSOR = new MapFunc<Cursor, Tweet>() {
         @NonNull
-        @Override public Tweet map(@NonNull Cursor cursor) {
+        @Override
+        public Tweet map(@NonNull Cursor cursor) {
             return new Tweet(
                     cursor.getLong(cursor.getColumnIndex(COLUMN_ID)),
                     cursor.getString(cursor.getColumnIndex(COLUMN_AUTHOR)),
@@ -44,7 +46,8 @@ public class Tweet {
 
     public static final MapFunc<Tweet, ContentValues> MAP_TO_CONTENT_VALUES = new MapFunc<Tweet, ContentValues>() {
         @NonNull
-        @Override public ContentValues map(@NonNull Tweet tweet) {
+        @Override
+        public ContentValues map(@NonNull Tweet tweet) {
             final ContentValues contentValues = new ContentValues(3); // wow, such optimization
 
             contentValues.put(COLUMN_ID, tweet.id);
@@ -55,16 +58,31 @@ public class Tweet {
         }
     };
 
-    public static final Query GET_ALL_QUERY = new Query.Builder()
+    public static final MapFunc<Tweet, DeleteQuery> MAP_TO_DELETE_QUERY = new MapFunc<Tweet, DeleteQuery>() {
+        @NonNull
+        @Override
+        public DeleteQuery map(@NonNull Tweet tweet) {
+            return new DeleteQuery.Builder()
+                    .table(TABLE)
+                    .where(COLUMN_ID + "=?")
+                    .whereArgs(tweet.getId())
+                    .build();
+        }
+    };
+
+    public static final Query QUERY_GET_ALL = new Query.Builder()
             .table(TABLE)
             .build();
 
     public static final PutResolver<Tweet> PUT_RESOLVER = new DefaultPutResolver<Tweet>() {
-        @NonNull @Override protected String getTable() {
+        @NonNull
+        @Override
+        protected String getTable() {
             return TABLE;
         }
 
-        @Override public void afterPut(@NonNull Tweet object, @NonNull PutResult putResult) {
+        @Override
+        public void afterPut(@NonNull Tweet object, @NonNull PutResult putResult) {
             if (putResult.wasInserted()) {
                 object.id = putResult.insertedId();
             }
@@ -72,10 +90,13 @@ public class Tweet {
     };
 
     // if object was not inserted into db, id will be null
-    @Nullable private volatile Long id;
+    @Nullable
+    private volatile Long id;
 
-    @NonNull private final String author;
-    @NonNull private final String content;
+    @NonNull
+    private final String author;
+    @NonNull
+    private final String content;
 
     private Tweet(Long id, @NonNull String author, @NonNull String content) {
         this.id = id;
@@ -83,19 +104,23 @@ public class Tweet {
         this.content = content;
     }
 
-    @NonNull public static Tweet newTweet(@NonNull String author, @NonNull String content) {
+    @NonNull
+    public static Tweet newTweet(@NonNull String author, @NonNull String content) {
         return new Tweet(null, author, content);
     }
 
-    @Nullable public Long getId() {
+    @Nullable
+    public Long getId() {
         return id;
     }
 
-    @NonNull public String getAuthor() {
+    @NonNull
+    public String getAuthor() {
         return author;
     }
 
-    @NonNull public String getContent() {
+    @NonNull
+    public String getContent() {
         return content;
     }
 

--- a/storio-sample-app/src/main/java/com/pushtorefresh/storio/sample/ui/fragment/TweetsFragment.java
+++ b/storio-sample-app/src/main/java/com/pushtorefresh/storio/sample/ui/fragment/TweetsFragment.java
@@ -86,8 +86,7 @@ public class TweetsFragment extends BaseFragment {
         final Subscription subscription = storIOSQLite
                 .get()
                 .listOfObjects(Tweet.class)
-                .withMapFunc(Tweet.MAP_FROM_CURSOR)
-                .withQuery(Tweet.GET_ALL_QUERY)
+                .withQuery(Tweet.QUERY_GET_ALL)
                 .prepare()
                 .createObservableStream() // it will be subscribed to changes in tweets table!
                 .delay(1, TimeUnit.SECONDS) // for better User Experience
@@ -133,9 +132,7 @@ public class TweetsFragment extends BaseFragment {
 
         storIOSQLite
                 .put()
-                .objects(tweets)
-                .withMapFunc(Tweet.MAP_TO_CONTENT_VALUES)
-                .withPutResolver(Tweet.PUT_RESOLVER)
+                .objects(Tweet.class, tweets)
                 .prepare()
                 .createObservable()
                 .subscribeOn(Schedulers.io())

--- a/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/BaseTest.java
+++ b/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/BaseTest.java
@@ -55,10 +55,10 @@ public abstract class BaseTest {
         return storIOSQLite
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(User.MAP_FROM_CURSOR)
                 .withQuery(new Query.Builder()
                         .table(User.TABLE)
                         .build())
+                .withMapFunc(User.MAP_FROM_CURSOR)
                 .prepare()
                 .executeAsBlocking();
     }
@@ -96,7 +96,7 @@ public abstract class BaseTest {
 
         final PutResults<User> putResults = storIOSQLite
                 .put()
-                .objects(users)
+                .objects(User.class, users)
                 .withMapFunc(User.MAP_TO_CONTENT_VALUES)
                 .withPutResolver(User.PUT_RESOLVER)
                 .prepare()

--- a/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/DeleteTest.java
+++ b/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/DeleteTest.java
@@ -40,7 +40,7 @@ public class DeleteTest extends BaseTest {
 
         final DeleteResults<User> deleteResults = storIOSQLite
                 .delete()
-                .objects(usersToDelete)
+                .objects(User.class, usersToDelete)
                 .withMapFunc(User.MAP_TO_DELETE_QUERY)
                 .prepare()
                 .executeAsBlocking();

--- a/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/QueryTest.java
+++ b/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/QueryTest.java
@@ -38,12 +38,12 @@ public class QueryTest extends BaseTest {
             final List<User> usersFromQuery = storIOSQLite
                     .get()
                     .listOfObjects(User.class)
-                    .withMapFunc(User.MAP_FROM_CURSOR)
                     .withQuery(new Query.Builder()
                             .table(User.TABLE)
                             .where(User.COLUMN_EMAIL + "=?")
                             .whereArgs(user.getEmail())
                             .build())
+                    .withMapFunc(User.MAP_FROM_CURSOR)
                     .prepare()
                     .executeAsBlocking();
 
@@ -64,11 +64,11 @@ public class QueryTest extends BaseTest {
         final List<User> usersFromQueryOrdered = storIOSQLite
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(User.MAP_FROM_CURSOR)
                 .withQuery(new Query.Builder()
                         .table(User.TABLE)
                         .orderBy(User.COLUMN_EMAIL)
                         .build())
+                .withMapFunc(User.MAP_FROM_CURSOR)
                 .prepare()
                 .executeAsBlocking();
 
@@ -94,11 +94,11 @@ public class QueryTest extends BaseTest {
         final List<User> usersFromQueryOrdered = storIOSQLite
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(User.MAP_FROM_CURSOR)
                 .withQuery(new Query.Builder()
                         .table(User.TABLE)
                         .orderBy(User.COLUMN_EMAIL + " DESC")
                         .build())
+                .withMapFunc(User.MAP_FROM_CURSOR)
                 .prepare()
                 .executeAsBlocking();
 
@@ -120,11 +120,11 @@ public class QueryTest extends BaseTest {
         final List<User> usersFromQuery = storIOSQLite
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(User.MAP_FROM_CURSOR)
                 .withQuery(new Query.Builder()
                         .table(User.TABLE)
                         .limit(String.valueOf(limit))
                         .build())
+                .withMapFunc(User.MAP_FROM_CURSOR)
                 .prepare()
                 .executeAsBlocking();
 
@@ -140,12 +140,12 @@ public class QueryTest extends BaseTest {
         final List<User> usersFromQuery = storIOSQLite
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(User.MAP_FROM_CURSOR)
                 .withQuery(new Query.Builder()
                         .table(User.TABLE)
                         .orderBy(User.COLUMN_EMAIL)
                         .limit(offset + ", " + limit)
                         .build())
+                .withMapFunc(User.MAP_FROM_CURSOR)
                 .prepare()
                 .executeAsBlocking();
 
@@ -178,12 +178,12 @@ public class QueryTest extends BaseTest {
         final List<User> groupsOfUsers = storIOSQLite
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(mapFuncOnlyEmail)
                 .withQuery(new Query.Builder()
                         .table(User.TABLE)
                         .columns(User.COLUMN_EMAIL)
                         .groupBy(User.COLUMN_EMAIL)
                         .build())
+                .withMapFunc(mapFuncOnlyEmail)
                 .prepare()
                 .executeAsBlocking();
 
@@ -211,13 +211,13 @@ public class QueryTest extends BaseTest {
         final List<User> groupsOfUsers = storIOSQLite
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(mapFuncOnlyEmail)
                 .withQuery(new Query.Builder()
                         .table(User.TABLE)
                         .columns(User.COLUMN_EMAIL)
                         .groupBy(User.COLUMN_EMAIL)
                         .having("COUNT(*) >= " + bigGroupThreshold)
                         .build())
+                .withMapFunc(mapFuncOnlyEmail)
                 .prepare()
                 .executeAsBlocking();
 
@@ -237,12 +237,12 @@ public class QueryTest extends BaseTest {
         final List<User> uniqueUsersFromQuery = storIOSQLite
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(mapFuncOnlyEmail)
                 .withQuery(new Query.Builder()
                         .table(User.TABLE)
                         .distinct(true)
                         .columns(User.COLUMN_EMAIL)
                         .build())
+                .withMapFunc(mapFuncOnlyEmail)
                 .prepare()
                 .executeAsBlocking();
 
@@ -252,12 +252,12 @@ public class QueryTest extends BaseTest {
         final List<User> allUsersFromQuery = storIOSQLite
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(mapFuncOnlyEmail)
                 .withQuery(new Query.Builder()
                         .table(User.TABLE)
                         .distinct(false)
                         .columns(User.COLUMN_EMAIL)
                         .build())
+                .withMapFunc(mapFuncOnlyEmail)
                 .prepare()
                 .executeAsBlocking();
 
@@ -306,10 +306,10 @@ public class QueryTest extends BaseTest {
         final List<User> usersFromQuery = storIOSQLite
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(User.MAP_FROM_CURSOR)
                 .withQuery(new RawQuery.Builder()
                         .query(query)
                         .build())
+                .withMapFunc(User.MAP_FROM_CURSOR)
                 .prepare()
                 .executeAsBlocking();
 
@@ -330,11 +330,11 @@ public class QueryTest extends BaseTest {
         final List<User> usersFromQuery = storIOSQLite
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(User.MAP_FROM_CURSOR)
                 .withQuery(new RawQuery.Builder()
                         .query(query)
                         .args(testUser.getEmail())
                         .build())
+                .withMapFunc(User.MAP_FROM_CURSOR)
                 .prepare()
                 .executeAsBlocking();
 
@@ -353,11 +353,11 @@ public class QueryTest extends BaseTest {
 
         storIOSQLite.get()
                 .listOfObjects(User.class)
-                .withMapFunc(User.MAP_FROM_CURSOR)
                 .withQuery(new RawQuery.Builder()
                         .query(query)
                         .args(arg)
                         .build())
+                .withMapFunc(User.MAP_FROM_CURSOR)
                 .prepare()
                 .executeAsBlocking();
 

--- a/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/UpdateTest.java
+++ b/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/UpdateTest.java
@@ -62,7 +62,7 @@ public class UpdateTest extends BaseTest {
 
         final PutResults<User> insertResults = storIOSQLite
                 .put()
-                .objects(usersForInsert)
+                .objects(User.class, usersForInsert)
                 .withMapFunc(User.MAP_TO_CONTENT_VALUES)
                 .withPutResolver(User.PUT_RESOLVER)
                 .prepare()
@@ -78,7 +78,7 @@ public class UpdateTest extends BaseTest {
 
         final PutResults<User> updateResults = storIOSQLite
                 .put()
-                .objects(usersForUpdate)
+                .objects(User.class, usersForUpdate)
                 .withMapFunc(User.MAP_TO_CONTENT_VALUES)
                 .withPutResolver(User.PUT_RESOLVER)
                 .prepare()

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/SQLiteTypeDefaults.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/SQLiteTypeDefaults.java
@@ -1,0 +1,223 @@
+package com.pushtorefresh.storio.sqlite;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.pushtorefresh.storio.operation.MapFunc;
+import com.pushtorefresh.storio.sqlite.operation.delete.DeleteResolver;
+import com.pushtorefresh.storio.sqlite.operation.get.GetResolver;
+import com.pushtorefresh.storio.sqlite.operation.put.PutResolver;
+import com.pushtorefresh.storio.sqlite.query.DeleteQuery;
+
+import static com.pushtorefresh.storio.util.Checks.checkNotNull;
+
+/**
+ * SQLite Type definition for object mapping
+ *
+ * @param <T> type
+ */
+public class SQLiteTypeDefaults<T> {
+
+    @NonNull
+    public final MapFunc<T, ContentValues> mapToContentValues;
+
+    @NonNull
+    public final MapFunc<Cursor, T> mapFromCursor;
+
+    @NonNull
+    public final PutResolver<T> putResolver;
+
+    @NonNull
+    public final MapFunc<T, DeleteQuery> mapToDeleteQuery;
+
+    @Nullable
+    public final GetResolver getResolver;
+
+    @Nullable
+    public final DeleteResolver deleteResolver;
+
+    SQLiteTypeDefaults(@NonNull MapFunc<T, ContentValues> mapToContentValues,
+                       @NonNull MapFunc<Cursor, T> mapFromCursor,
+                       @NonNull PutResolver<T> putResolver,
+                       @NonNull MapFunc<T, DeleteQuery> mapToDeleteQuery,
+                       @Nullable GetResolver getResolver,
+                       @Nullable DeleteResolver deleteResolver) {
+        this.mapToContentValues = mapToContentValues;
+        this.mapFromCursor = mapFromCursor;
+        this.putResolver = putResolver;
+        this.mapToDeleteQuery = mapToDeleteQuery;
+        this.getResolver = getResolver;
+        this.deleteResolver = deleteResolver;
+    }
+
+    /**
+     * Builder for {@link SQLiteTypeDefaults}
+     */
+    public static class Builder<T> {
+
+        /**
+         * Required: Specifies map function that will be used to map object of required type to {@link ContentValues}
+         *
+         * @param mapFunc non-null map function
+         * @return builder
+         */
+        @NonNull
+        public MapToContentValuesBuilder<T> mappingToContentValues(@NonNull MapFunc<T, ContentValues> mapFunc) {
+            return new MapToContentValuesBuilder<T>(mapFunc);
+        }
+    }
+
+    /**
+     * Compile-time safe part of builder for {@link SQLiteTypeDefaults}
+     *
+     * @param <T> type
+     */
+    public static class MapToContentValuesBuilder<T> {
+
+        private final MapFunc<T, ContentValues> mapToContentValues;
+
+        MapToContentValuesBuilder(MapFunc<T, ContentValues> mapToContentValues) {
+            this.mapToContentValues = mapToContentValues;
+        }
+
+        /**
+         * Required: Specifies map function that will be used to map {@link Cursor} to object of required type
+         *
+         * @param mapFunc non-null map function
+         * @return builder
+         */
+        @NonNull
+        public MapFromCursorBuilder<T> mappingFromCursor(@NonNull MapFunc<Cursor, T> mapFunc) {
+            return new MapFromCursorBuilder<T>(mapToContentValues, mapFunc);
+        }
+    }
+
+    /**
+     * Compile-time safe part of builder for {@link SQLiteTypeDefaults}
+     *
+     * @param <T> type
+     */
+    public static class MapFromCursorBuilder<T> {
+
+        private final MapFunc<T, ContentValues> mapToContentValues;
+        private final MapFunc<Cursor, T> mapFromCursor;
+
+        MapFromCursorBuilder(MapFunc<T, ContentValues> mapToContentValues,
+                             MapFunc<Cursor, T> mapFromCursor) {
+            this.mapToContentValues = mapToContentValues;
+            this.mapFromCursor = mapFromCursor;
+        }
+
+        /**
+         * Required: Specifies Resolver for Put Operation
+         *
+         * @param putResolver non-null resolver for Put Operation
+         * @return builder
+         */
+        @NonNull
+        public PutResolverBuilder<T> putResolver(@NonNull PutResolver<T> putResolver) {
+            return new PutResolverBuilder<T>(mapToContentValues, mapFromCursor, putResolver);
+        }
+    }
+
+    /**
+     * Compile-time safe part of builder for {@link SQLiteTypeDefaults}
+     *
+     * @param <T> type
+     */
+    public static class PutResolverBuilder<T> {
+        private final MapFunc<T, ContentValues> mapToContentValues;
+        private final MapFunc<Cursor, T> mapFromCursor;
+        private final PutResolver<T> putResolver;
+
+        public PutResolverBuilder(MapFunc<T, ContentValues> mapToContentValues, MapFunc<Cursor, T> mapFromCursor, PutResolver<T> putResolver) {
+            this.mapToContentValues = mapToContentValues;
+            this.mapFromCursor = mapFromCursor;
+            this.putResolver = putResolver;
+        }
+
+        /**
+         * Required: Specifies map function that will be used to map object or required type to {@link DeleteQuery}
+         *
+         * @param mapFunc non-null map function
+         * @return builder
+         */
+        @NonNull
+        public CompleteBuilder<T> mappingToDeleteQuery(@NonNull MapFunc<T, DeleteQuery> mapFunc) {
+            return new CompleteBuilder<T>(
+                    mapToContentValues,
+                    mapFromCursor,
+                    putResolver,
+                    mapFunc
+            );
+        }
+    }
+
+    public static class CompleteBuilder<T> {
+
+        private final MapFunc<T, ContentValues> mapToContentValues;
+        private final MapFunc<Cursor, T> mapFromCursor;
+        private final PutResolver<T> putResolver;
+        private final MapFunc<T, DeleteQuery> mapToDeleteQuery;
+
+        private GetResolver getResolver;
+        private DeleteResolver deleteResolver;
+
+        CompleteBuilder(MapFunc<T, ContentValues> mapToContentValues,
+                        MapFunc<Cursor, T> mapFromCursor,
+                        PutResolver<T> putResolver,
+                        MapFunc<T, DeleteQuery> mapToDeleteQuery) {
+            this.mapToContentValues = mapToContentValues;
+            this.mapFromCursor = mapFromCursor;
+            this.putResolver = putResolver;
+            this.mapToDeleteQuery = mapToDeleteQuery;
+        }
+
+        /**
+         * Optional: Specifies resolver for Get Operation
+         *
+         * @param getResolver resolver for Get Operation
+         * @return builder
+         */
+        @NonNull
+        public CompleteBuilder<T> getResolver(@Nullable GetResolver getResolver) {
+            this.getResolver = getResolver;
+            return this;
+        }
+
+        /**
+         * Optional: Specifies resolver for Delete Operation
+         *
+         * @param deleteResolver resolver for Delete Operation
+         * @return builder
+         */
+        @NonNull
+        public CompleteBuilder<T> deleteResolver(@Nullable DeleteResolver deleteResolver) {
+            this.deleteResolver = deleteResolver;
+            return this;
+        }
+
+        /**
+         * Builds new immutable instance of {@link SQLiteTypeDefaults}
+         *
+         * @return new immutable instance of {@link SQLiteTypeDefaults}
+         */
+        @NonNull
+        public SQLiteTypeDefaults<T> build() {
+            checkNotNull(mapToContentValues, "Please specify mapping to ContentValues");
+            checkNotNull(mapFromCursor, "Please specify mapping from Cursor");
+            checkNotNull(putResolver, "Please specify PutResolver");
+            checkNotNull(mapToDeleteQuery, "Please specify mapping to DeleteQuery");
+
+            return new SQLiteTypeDefaults<T>(
+                    mapToContentValues,
+                    mapFromCursor,
+                    putResolver,
+                    mapToDeleteQuery,
+                    getResolver, deleteResolver);
+        }
+    }
+
+}

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/StorIOSQLite.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/StorIOSQLite.java
@@ -3,6 +3,7 @@ package com.pushtorefresh.storio.sqlite;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.pushtorefresh.storio.LogListener;
 import com.pushtorefresh.storio.Loggi;
@@ -23,7 +24,7 @@ import rx.Observable;
 
 /**
  * Powerful abstraction for databases
- * <p/>
+ * <p>
  * It's an abstract class instead of interface because we want to have ability to add some
  * changes without breaking existing implementations
  */
@@ -35,7 +36,8 @@ public abstract class StorIOSQLite {
      *
      * @return builder for PreparedExecSql
      */
-    @NonNull public PreparedExecSql.Builder execSql() {
+    @NonNull
+    public PreparedExecSql.Builder execSql() {
         return new PreparedExecSql.Builder(this);
     }
 
@@ -45,7 +47,8 @@ public abstract class StorIOSQLite {
      *
      * @return builder for PreparedGet
      */
-    @NonNull public PreparedGet.Builder get() {
+    @NonNull
+    public PreparedGet.Builder get() {
         return new PreparedGet.Builder(this);
     }
 
@@ -55,7 +58,8 @@ public abstract class StorIOSQLite {
      *
      * @return builder for PreparedPut
      */
-    @NonNull public PreparedPut.Builder put() {
+    @NonNull
+    public PreparedPut.Builder put() {
         return new PreparedPut.Builder(this);
     }
 
@@ -65,7 +69,8 @@ public abstract class StorIOSQLite {
      *
      * @return builder for PreparedDelete
      */
-    @NonNull public PreparedDelete.Builder delete() {
+    @NonNull
+    public PreparedDelete.Builder delete() {
         return new PreparedDelete.Builder(this);
     }
 
@@ -116,7 +121,8 @@ public abstract class StorIOSQLite {
      *
      * @return implementation of Internal operations for {@link StorIOSQLite}
      */
-    @NonNull public abstract Internal internal();
+    @NonNull
+    public abstract Internal internal();
 
     /**
      * Hides some internal operations of {@link StorIOSQLite}
@@ -127,7 +133,20 @@ public abstract class StorIOSQLite {
         /**
          * Log wrapper for internal usage only.
          */
-        @NonNull private final Loggi loggi = new Loggi();
+        @NonNull
+        private final Loggi loggi = new Loggi();
+
+        /**
+         * Gets {@link SQLiteTypeDefaults} for some type
+         * <p>
+         * Result can be null
+         *
+         * @param type type
+         * @param <T>  type
+         * @return {@link SQLiteTypeDefaults} for required type or null
+         */
+        @Nullable
+        public abstract <T> SQLiteTypeDefaults<T> typeDefaults(@NonNull Class<T> type);
 
         /**
          * Execute a single SQL statement that is NOT a SELECT/INSERT/UPDATE/DELETE on the database
@@ -142,7 +161,8 @@ public abstract class StorIOSQLite {
          * @param rawQuery sql query
          * @return A Cursor object, which is positioned before the first entry. Note that Cursors are not synchronized, see the documentation for more details.
          */
-        @NonNull public abstract Cursor rawQuery(@NonNull RawQuery rawQuery);
+        @NonNull
+        public abstract Cursor rawQuery(@NonNull RawQuery rawQuery);
 
         /**
          * Executes query on the database and returns {@link android.database.Cursor} over the result set
@@ -150,7 +170,8 @@ public abstract class StorIOSQLite {
          * @param query sql query
          * @return A Cursor object, which is positioned before the first entry. Note that Cursors are not synchronized, see the documentation for more details.
          */
-        @NonNull public abstract Cursor query(@NonNull Query query);
+        @NonNull
+        public abstract Cursor query(@NonNull Query query);
 
         /**
          * Inserts a row into the database

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/delete/PreparedDelete.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/delete/PreparedDelete.java
@@ -6,8 +6,6 @@ import com.pushtorefresh.storio.operation.PreparedOperation;
 import com.pushtorefresh.storio.sqlite.StorIOSQLite;
 import com.pushtorefresh.storio.sqlite.query.DeleteQuery;
 
-import java.util.Collection;
-
 public abstract class PreparedDelete<T> implements PreparedOperation<T> {
 
     @NonNull
@@ -59,13 +57,14 @@ public abstract class PreparedDelete<T> implements PreparedOperation<T> {
         /**
          * Prepares Delete Operation which should delete multiple objects
          *
+         * @param type type of objects, due to limitations of Generics in Java we have to explicitly ask you about type of objects, sorry :(
          * @param objects objects to delete
          * @param <T>     type of objects
          * @return builder
          */
         @NonNull
-        public <T> PreparedDeleteObjects.Builder<T> objects(@NonNull Collection<T> objects) {
-            return new PreparedDeleteObjects.Builder<T>(storIOSQLite, objects);
+        public <T> PreparedDeleteObjects.Builder<T> objects(@NonNull Class<T> type, @NonNull Iterable<T> objects) {
+            return new PreparedDeleteObjects.Builder<T>(storIOSQLite, type, objects);
         }
     }
 }

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/delete/PreparedDeleteObject.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/delete/PreparedDeleteObject.java
@@ -1,9 +1,11 @@
 package com.pushtorefresh.storio.sqlite.operation.delete;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.pushtorefresh.storio.operation.MapFunc;
 import com.pushtorefresh.storio.sqlite.Changes;
+import com.pushtorefresh.storio.sqlite.SQLiteTypeDefaults;
 import com.pushtorefresh.storio.sqlite.StorIOSQLite;
 import com.pushtorefresh.storio.sqlite.query.DeleteQuery;
 import com.pushtorefresh.storio.util.EnvironmentUtil;
@@ -97,22 +99,25 @@ public class PreparedDeleteObject<T> extends PreparedDelete<DeleteResult> {
         }
 
         /**
-         * Specifies map function to map object to {@link DeleteQuery}
+         * Optional: Specifies map function to map object to {@link DeleteQuery}
+         * <p/>
+         * Can be set via {@link SQLiteTypeDefaults},
+         * If map function is not set via {@link SQLiteTypeDefaults} or explicitly, exception will be thrown
          *
          * @param mapFunc map function to map object to {@link DeleteQuery}
          * @return builder
          */
         @NonNull
-        public Builder<T> withMapFunc(@NonNull MapFunc<T, DeleteQuery> mapFunc) {
+        public Builder<T> withMapFunc(@Nullable MapFunc<T, DeleteQuery> mapFunc) {
             this.mapFunc = mapFunc;
             return this;
         }
 
-
         /**
          * Optional: Specifies {@link DeleteResolver} for Delete Operation
-         * <p>
-         * Default value is instance of {@link DefaultDeleteResolver}
+         * <p/>
+         * Can be set via {@link SQLiteTypeDefaults},
+         * If resolver is not set via {@link SQLiteTypeDefaults}, {@link DefaultDeleteResolver} will be used
          *
          * @param deleteResolver delete resolver
          * @return builder
@@ -128,8 +133,15 @@ public class PreparedDeleteObject<T> extends PreparedDelete<DeleteResult> {
          *
          * @return {@link PreparedDeleteObject} instance
          */
+        @SuppressWarnings("unchecked")
         @NonNull
         public PreparedDeleteObject<T> prepare() {
+            final SQLiteTypeDefaults<T> typeDefinition = storIOSQLite.internal().typeDefaults((Class<T>) object.getClass());
+
+            if (mapFunc == null && typeDefinition != null) {
+                mapFunc = typeDefinition.mapToDeleteQuery;
+            }
+
             if (deleteResolver == null) {
                 deleteResolver = DefaultDeleteResolver.INSTANCE;
             }

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/put/PreparedPut.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/put/PreparedPut.java
@@ -3,8 +3,8 @@ package com.pushtorefresh.storio.sqlite.operation.put;
 import android.content.ContentValues;
 import android.support.annotation.NonNull;
 
-import com.pushtorefresh.storio.sqlite.StorIOSQLite;
 import com.pushtorefresh.storio.operation.PreparedOperation;
+import com.pushtorefresh.storio.sqlite.StorIOSQLite;
 
 import java.util.Arrays;
 
@@ -87,26 +87,28 @@ public abstract class PreparedPut<T, Result> implements PreparedOperation<Result
         /**
          * Prepares Put Operation for multiple objects
          *
+         * @param type    type of objects, due to limitations of Generics in Java we have to explicitly ask you about type of objects, sorry :(
          * @param objects objects to put
          * @param <T>     type of objects
          * @return builder
          */
         @NonNull
-        public <T> PreparedPutObjects.Builder<T> objects(@NonNull Iterable<T> objects) {
-            return new PreparedPutObjects.Builder<T>(storIOSQLite, objects);
+        public <T> PreparedPutObjects.Builder<T> objects(@NonNull Class<T> type, @NonNull Iterable<T> objects) {
+            return new PreparedPutObjects.Builder<T>(storIOSQLite, type, objects);
         }
 
         /**
          * Prepares Put Operation for multiple objects
          *
+         * @param type    type of objects, due to limitations of Generics in Java we have to explicitly ask you about type of objects, sorry :(
          * @param objects objects to put
          * @param <T>     type of objects
          * @return builder
          */
         @SuppressWarnings("unchecked")
         @NonNull
-        public final <T> PreparedPutObjects.Builder<T> objects(@NonNull T... objects) {
-            return new PreparedPutObjects.Builder<T>(storIOSQLite, Arrays.asList(objects));
+        public final <T> PreparedPutObjects.Builder<T> objects(@NonNull Class<T> type, @NonNull T... objects) {
+            return new PreparedPutObjects.Builder<T>(storIOSQLite, type, Arrays.asList(objects));
         }
     }
 }

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/put/PreparedPutObject.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/put/PreparedPutObject.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import com.pushtorefresh.storio.operation.MapFunc;
 import com.pushtorefresh.storio.operation.internal.OnSubscribeExecuteAsBlocking;
 import com.pushtorefresh.storio.sqlite.Changes;
+import com.pushtorefresh.storio.sqlite.SQLiteTypeDefaults;
 import com.pushtorefresh.storio.sqlite.StorIOSQLite;
 import com.pushtorefresh.storio.util.EnvironmentUtil;
 
@@ -75,8 +76,11 @@ public class PreparedPutObject<T> extends PreparedPut<T, PutResult> {
         }
 
         /**
-         * Required: Specifies map function for Put Operation
+         * Optional: Specifies map function for Put Operation
          * which will be used to map object to {@link ContentValues}
+         * <p>
+         * Can be set via {@link SQLiteTypeDefaults}
+         * If it's not set via {@link SQLiteTypeDefaults} or explicitly, exception will be thrown
          *
          * @param mapFunc map function for Put Operation which will be used to map object to {@link ContentValues}
          * @return builder
@@ -88,8 +92,11 @@ public class PreparedPutObject<T> extends PreparedPut<T, PutResult> {
         }
 
         /**
-         * Required: Specifies {@link PutResolver} for Put Operation
+         * Optional: Specifies {@link PutResolver} for Put Operation
          * which allows you to customize behavior of Put Operation
+         * <p>
+         * Can be set via {@link SQLiteTypeDefaults}
+         * If it's not set via {@link SQLiteTypeDefaults} or explicitly, exception will be thrown
          *
          * @param putResolver put resolver
          * @return builder
@@ -106,8 +113,19 @@ public class PreparedPutObject<T> extends PreparedPut<T, PutResult> {
          *
          * @return {@link PreparedPutObject} instance
          */
+        @SuppressWarnings("unchecked")
         @NonNull
         public PreparedPutObject<T> prepare() {
+            final SQLiteTypeDefaults<T> typeDefaults = storIOSQLite.internal().typeDefaults((Class<T>) object.getClass());
+
+            if (mapFunc == null && typeDefaults != null) {
+                mapFunc = typeDefaults.mapToContentValues;
+            }
+
+            if (putResolver == null && typeDefaults != null) {
+                putResolver = typeDefaults.putResolver;
+            }
+
             checkNotNull(mapFunc, "Please specify map function");
             checkNotNull(putResolver, "Please specify put resolver");
 

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/put/PutResolver.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/put/PutResolver.java
@@ -16,7 +16,7 @@ public interface PutResolver<T> {
     /**
      * Performs Put Operation of some {@link ContentValues} into {@link StorIOSQLite}
      *
-     * @param storIOSQLite      instance of {@link StorIOSQLite}
+     * @param storIOSQLite  instance of {@link StorIOSQLite}
      * @param contentValues some {@link ContentValues} to put
      * @return non-null result of Put Operation
      */

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/SQLiteTypeDefaultsTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/SQLiteTypeDefaultsTest.java
@@ -1,0 +1,82 @@
+package com.pushtorefresh.storio.sqlite;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+
+import com.pushtorefresh.storio.operation.MapFunc;
+import com.pushtorefresh.storio.sqlite.operation.delete.DeleteResolver;
+import com.pushtorefresh.storio.sqlite.operation.get.GetResolver;
+import com.pushtorefresh.storio.sqlite.operation.put.PutResolver;
+import com.pushtorefresh.storio.sqlite.query.DeleteQuery;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class SQLiteTypeDefaultsTest {
+
+    @SuppressWarnings({"ConstantConditions", "unchecked"})
+    @Test(expected = NullPointerException.class)
+    public void nullMapToContentValues() {
+        new SQLiteTypeDefaults.Builder<Object>()
+                .mappingToContentValues(null)
+                .mappingFromCursor(mock(MapFunc.class))
+                .putResolver(mock(PutResolver.class))
+                .mappingToDeleteQuery(mock(MapFunc.class))
+                .build();
+    }
+
+    @SuppressWarnings({"ConstantConditions", "unchecked"})
+    @Test(expected = NullPointerException.class)
+    public void nullMapFromCursor() {
+        new SQLiteTypeDefaults.Builder<Object>()
+                .mappingToContentValues(mock(MapFunc.class))
+                .mappingFromCursor(null)
+                .putResolver(mock(PutResolver.class))
+                .mappingToDeleteQuery(mock(MapFunc.class))
+                .build();
+    }
+
+    @SuppressWarnings({"ConstantConditions", "unchecked"})
+    @Test(expected = NullPointerException.class)
+    public void nullMapToDeleteQuery() {
+        new SQLiteTypeDefaults.Builder<Object>()
+                .mappingToContentValues(mock(MapFunc.class))
+                .mappingFromCursor(mock(MapFunc.class))
+                .putResolver(mock(PutResolver.class))
+                .mappingToDeleteQuery(null)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void build() {
+        class TestItem {
+
+        }
+
+        final MapFunc<TestItem, ContentValues> mapToContentValues = mock(MapFunc.class);
+        final MapFunc<Cursor, TestItem> mapFromCursor = mock(MapFunc.class);
+        final PutResolver<TestItem> putResolver = mock(PutResolver.class);
+        final MapFunc<TestItem, DeleteQuery> mapToDeleteQuery = mock(MapFunc.class);
+        final GetResolver getResolver = mock(GetResolver.class);
+        final DeleteResolver deleteResolver = mock(DeleteResolver.class);
+
+        final SQLiteTypeDefaults<TestItem> sqliteTypeDefaults = new SQLiteTypeDefaults.Builder<TestItem>()
+                .mappingToContentValues(mapToContentValues)
+                .mappingFromCursor(mapFromCursor)
+                .putResolver(putResolver)
+                .mappingToDeleteQuery(mapToDeleteQuery)
+                .getResolver(getResolver)
+                .deleteResolver(deleteResolver)
+                .build();
+
+        assertEquals(mapToContentValues, sqliteTypeDefaults.mapToContentValues);
+        assertEquals(mapFromCursor, sqliteTypeDefaults.mapFromCursor);
+        assertEquals(putResolver, sqliteTypeDefaults.putResolver);
+        assertEquals(mapToDeleteQuery, sqliteTypeDefaults.mapToDeleteQuery);
+        assertEquals(getResolver, sqliteTypeDefaults.getResolver);
+        assertEquals(deleteResolver, sqliteTypeDefaults.deleteResolver);
+    }
+}

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/design/DeleteOperationDesignTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/design/DeleteOperationDesignTest.java
@@ -40,7 +40,7 @@ public class DeleteOperationDesignTest extends OperationDesignTest {
 
         DeleteResults<User> deleteResult = storIOSQLite()
                 .delete()
-                .objects(users)
+                .objects(User.class, users)
                 .withMapFunc(User.MAP_TO_DELETE_QUERY)
                 .prepare()
                 .executeAsBlocking();
@@ -51,7 +51,7 @@ public class DeleteOperationDesignTest extends OperationDesignTest {
 
         Observable<DeleteResults<User>> deleteResultObservable = storIOSQLite()
                 .delete()
-                .objects(users)
+                .objects(User.class, users)
                 .withMapFunc(User.MAP_TO_DELETE_QUERY)
                 .prepare()
                 .createObservable();

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/design/DesignTestStorIOSQLite.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/design/DesignTestStorIOSQLite.java
@@ -3,7 +3,9 @@ package com.pushtorefresh.storio.sqlite.design;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
+import com.pushtorefresh.storio.sqlite.SQLiteTypeDefaults;
 import com.pushtorefresh.storio.sqlite.StorIOSQLite;
 import com.pushtorefresh.storio.sqlite.Changes;
 import com.pushtorefresh.storio.sqlite.operation.delete.PreparedDelete;
@@ -30,6 +32,13 @@ class DesignTestStorIOSQLite extends StorIOSQLite {
     }
 
     @NonNull private final Internal internal = new Internal() {
+
+        @Nullable
+        @Override
+        public <T> SQLiteTypeDefaults<T> typeDefaults(@NonNull Class<T> type) {
+            // no impl
+            return null;
+        }
 
         @Override public void execSql(@NonNull RawQuery rawQuery) {
             // no impl

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/design/GetOperationDesignTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/design/GetOperationDesignTest.java
@@ -32,12 +32,12 @@ public class GetOperationDesignTest extends OperationDesignTest {
         List<User> users = storIOSQLite()
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(User.MAP_FROM_CURSOR)
                 .withQuery(new Query.Builder()
                         .table("users")
                         .where("email = ?")
                         .whereArgs("artem.zinnatullin@gmail.com")
                         .build())
+                .withMapFunc(User.MAP_FROM_CURSOR)
                 .prepare()
                 .executeAsBlocking();
     }
@@ -61,12 +61,12 @@ public class GetOperationDesignTest extends OperationDesignTest {
         Observable<List<User>> observableUsers = storIOSQLite()
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(User.MAP_FROM_CURSOR)
                 .withQuery(new Query.Builder()
                         .table("users")
                         .where("email = ?")
                         .whereArgs("artem.zinnatullin@gmail.com")
                         .build())
+                .withMapFunc(User.MAP_FROM_CURSOR)
                 .prepare()
                 .createObservable();
     }
@@ -102,11 +102,11 @@ public class GetOperationDesignTest extends OperationDesignTest {
         List<User> users = storIOSQLite()
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(User.MAP_FROM_CURSOR)
                 .withQuery(new RawQuery.Builder()
                         .query("SELECT FROM bla_bla join on bla_bla_bla WHERE x = ?")
                         .args("arg1", "arg2")
                         .build())
+                .withMapFunc(User.MAP_FROM_CURSOR)
                 .prepare()
                 .executeAsBlocking();
     }
@@ -116,11 +116,11 @@ public class GetOperationDesignTest extends OperationDesignTest {
         Observable<List<User>> usersObservable = storIOSQLite()
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(User.MAP_FROM_CURSOR)
                 .withQuery(new RawQuery.Builder()
                         .query("SELECT FROM bla_bla join on bla_bla_bla WHERE x = ?")
                         .args("arg1", "arg2")
                         .build())
+                .withMapFunc(User.MAP_FROM_CURSOR)
                 .prepare()
                 .createObservable();
     }
@@ -140,8 +140,8 @@ public class GetOperationDesignTest extends OperationDesignTest {
         Observable<List<User>> usersObservableStream = storIOSQLite()
                 .get()
                 .listOfObjects(User.class)
-                .withMapFunc(User.MAP_FROM_CURSOR)
                 .withQuery(new Query.Builder().table("users").build())
+                .withMapFunc(User.MAP_FROM_CURSOR)
                 .prepare()
                 .createObservableStream();
     }

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/design/PutOperationDesignTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/design/PutOperationDesignTest.java
@@ -46,7 +46,7 @@ public class PutOperationDesignTest extends OperationDesignTest {
 
         PutResults<User> putResults = storIOSQLite()
                 .put()
-                .objects(users)
+                .objects(User.class, users)
                 .withMapFunc(User.MAP_TO_CONTENT_VALUES)
                 .withPutResolver(User.PUT_RESOLVER)
                 .prepare()
@@ -59,7 +59,7 @@ public class PutOperationDesignTest extends OperationDesignTest {
 
         Observable<PutResults<User>> putResultsObservable = storIOSQLite()
                 .put()
-                .objects(users)
+                .objects(User.class, users)
                 .withMapFunc(User.MAP_TO_CONTENT_VALUES)
                 .withPutResolver(User.PUT_RESOLVER)
                 .prepare()
@@ -72,7 +72,7 @@ public class PutOperationDesignTest extends OperationDesignTest {
 
         PutResults<User> putResults = storIOSQLite()
                 .put()
-                .objects(users)
+                .objects(User.class, users)
                 .withMapFunc(User.MAP_TO_CONTENT_VALUES)
                 .withPutResolver(User.PUT_RESOLVER)
                 .prepare()
@@ -85,7 +85,7 @@ public class PutOperationDesignTest extends OperationDesignTest {
 
         Observable<PutResults<User>> putResultsObservable = storIOSQLite()
                 .put()
-                .objects(users)
+                .objects(User.class, users)
                 .withMapFunc(User.MAP_TO_CONTENT_VALUES)
                 .withPutResolver(User.PUT_RESOLVER)
                 .prepare()

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/impl/DefaultStorIOSQLiteTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/impl/DefaultStorIOSQLiteTest.java
@@ -3,8 +3,12 @@ package com.pushtorefresh.storio.sqlite.impl;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 
+import com.pushtorefresh.storio.sqlite.SQLiteTypeDefaults;
+import com.pushtorefresh.storio.sqlite.StorIOSQLite;
+
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -40,5 +44,40 @@ public class DefaultStorIOSQLiteTest {
                 .build();
 
         verify(sqLiteOpenHelper, times(1)).getWritableDatabase();
+    }
+
+    @SuppressWarnings({"ConstantConditions", "unchecked"})
+    @Test(expected = NullPointerException.class)
+    public void addTypeDefinitionNullType() {
+        new DefaultStorIOSQLite.Builder()
+                .db(mock(SQLiteDatabase.class))
+                .addDefaultsForType(null, mock(SQLiteTypeDefaults.class))
+                .build();
+    }
+
+    @SuppressWarnings({"unchecked", "ConstantConditions"})
+    @Test(expected = NullPointerException.class)
+    public void addTypeDefinitionNullDefinition() {
+        new DefaultStorIOSQLite.Builder()
+                .db(mock(SQLiteDatabase.class))
+                .addDefaultsForType(Object.class, null)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void typeDefinition() {
+        class TestItem {
+
+        }
+
+        final SQLiteTypeDefaults<TestItem> testItemTypeDefinition = mock(SQLiteTypeDefaults.class);
+
+        final StorIOSQLite storIOSQLite = new DefaultStorIOSQLite.Builder()
+                .db(mock(SQLiteDatabase.class))
+                .addDefaultsForType(TestItem.class, testItemTypeDefinition)
+                .build();
+
+        assertEquals(testItemTypeDefinition, storIOSQLite.internal().typeDefaults(TestItem.class));
     }
 }

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/operation/delete/PreparedDeleteTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/operation/delete/PreparedDeleteTest.java
@@ -188,7 +188,7 @@ public class PreparedDeleteTest {
 
         deleteMultipleStub.storIOSQLite
                 .delete()
-                .objects(deleteMultipleStub.users)
+                .objects(User.class, deleteMultipleStub.users)
                 .withMapFunc(deleteMultipleStub.mapFunc)
                 .withDeleteResolver(deleteMultipleStub.deleteResolver)
                 .prepare()
@@ -202,7 +202,7 @@ public class PreparedDeleteTest {
 
         deleteMultipleStub.storIOSQLite
                 .delete()
-                .objects(deleteMultipleStub.users)
+                .objects(User.class, deleteMultipleStub.users)
                 .withMapFunc(deleteMultipleStub.mapFunc)
                 .withDeleteResolver(deleteMultipleStub.deleteResolver)
                 .prepare()
@@ -218,10 +218,10 @@ public class PreparedDeleteTest {
 
         deleteMultipleStub.storIOSQLite
                 .delete()
-                .objects(deleteMultipleStub.users)
+                .objects(User.class, deleteMultipleStub.users)
                 .withMapFunc(deleteMultipleStub.mapFunc)
                 .withDeleteResolver(deleteMultipleStub.deleteResolver)
-                .dontUseTransaction()
+                .useTransaction(false)
                 .prepare()
                 .executeAsBlocking();
 
@@ -233,10 +233,10 @@ public class PreparedDeleteTest {
 
         deleteMultipleStub.storIOSQLite
                 .delete()
-                .objects(deleteMultipleStub.users)
+                .objects(User.class, deleteMultipleStub.users)
                 .withMapFunc(deleteMultipleStub.mapFunc)
                 .withDeleteResolver(deleteMultipleStub.deleteResolver)
-                .dontUseTransaction()
+                .useTransaction(false)
                 .prepare()
                 .createObservable()
                 .toBlocking()
@@ -250,10 +250,10 @@ public class PreparedDeleteTest {
 
         deleteMultipleStub.storIOSQLite
                 .delete()
-                .objects(deleteMultipleStub.users)
+                .objects(User.class, deleteMultipleStub.users)
                 .withMapFunc(deleteMultipleStub.mapFunc)
                 .withDeleteResolver(deleteMultipleStub.deleteResolver)
-                .useTransactionIfPossible()
+                .useTransaction(true)
                 .prepare()
                 .executeAsBlocking();
 
@@ -265,10 +265,10 @@ public class PreparedDeleteTest {
 
         deleteMultipleStub.storIOSQLite
                 .delete()
-                .objects(deleteMultipleStub.users)
+                .objects(User.class, deleteMultipleStub.users)
                 .withMapFunc(deleteMultipleStub.mapFunc)
                 .withDeleteResolver(deleteMultipleStub.deleteResolver)
-                .useTransactionIfPossible()
+                .useTransaction(true)
                 .prepare()
                 .createObservable()
                 .toBlocking()

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/operation/get/PreparedGetTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/operation/get/PreparedGetTest.java
@@ -54,6 +54,7 @@ public class PreparedGetTest {
 
     private static class GetStub {
         final StorIOSQLite storIOSQLite;
+        private final StorIOSQLite.Internal internal;
         final Query query;
         final RawQuery rawQuery;
         final GetResolver getResolver;
@@ -64,6 +65,11 @@ public class PreparedGetTest {
         @SuppressWarnings("unchecked")
         GetStub() {
             storIOSQLite = mock(StorIOSQLite.class);
+            internal = mock(StorIOSQLite.Internal.class);
+
+            when(storIOSQLite.internal())
+                    .thenReturn(internal);
+
             query = mock(Query.class);
             rawQuery = mock(RawQuery.class);
             getResolver = mock(GetResolver.class);
@@ -155,8 +161,8 @@ public class PreparedGetTest {
         final List<TestItem> testItems = getStub.storIOSQLite
                 .get()
                 .listOfObjects(TestItem.class)
-                .withMapFunc(getStub.mapFunc)
                 .withQuery(getStub.query)
+                .withMapFunc(getStub.mapFunc)
                 .withGetResolver(getStub.getResolver)
                 .prepare()
                 .executeAsBlocking();
@@ -189,8 +195,8 @@ public class PreparedGetTest {
         final List<TestItem> testItems = getStub.storIOSQLite
                 .get()
                 .listOfObjects(TestItem.class)
-                .withMapFunc(getStub.mapFunc)
                 .withQuery(getStub.query)
+                .withMapFunc(getStub.mapFunc)
                 .withGetResolver(getStub.getResolver)
                 .prepare()
                 .createObservable()
@@ -239,8 +245,8 @@ public class PreparedGetTest {
         final List<TestItem> testItems = getStub.storIOSQLite
                 .get()
                 .listOfObjects(TestItem.class)
-                .withMapFunc(getStub.mapFunc)
                 .withQuery(getStub.rawQuery)
+                .withMapFunc(getStub.mapFunc)
                 .withGetResolver(getStub.getResolver)
                 .prepare()
                 .executeAsBlocking();
@@ -255,8 +261,8 @@ public class PreparedGetTest {
         final List<TestItem> testItems = getStub.storIOSQLite
                 .get()
                 .listOfObjects(TestItem.class)
-                .withMapFunc(getStub.mapFunc)
                 .withQuery(getStub.rawQuery)
+                .withMapFunc(getStub.mapFunc)
                 .withGetResolver(getStub.getResolver)
                 .prepare()
                 .createObservable()

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/operation/put/PreparedPutObjectsTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/operation/put/PreparedPutObjectsTest.java
@@ -12,7 +12,7 @@ public class PreparedPutObjectsTest {
 
         final PutResults<TestItem> putResults = putStub.storIOSQLite
                 .put()
-                .objects(putStub.testItems)
+                .objects(TestItem.class, putStub.testItems)
                 .withMapFunc(putStub.mapFunc)
                 .withPutResolver(putStub.putResolver)
                 .prepare()
@@ -27,7 +27,7 @@ public class PreparedPutObjectsTest {
 
         final Observable<PutResults<TestItem>> putResultsObservable = putStub.storIOSQLite
                 .put()
-                .objects(putStub.testItems)
+                .objects(TestItem.class, putStub.testItems)
                 .withMapFunc(putStub.mapFunc)
                 .withPutResolver(putStub.putResolver)
                 .prepare()
@@ -42,10 +42,10 @@ public class PreparedPutObjectsTest {
 
         final PutResults<TestItem> putResults = putStub.storIOSQLite
                 .put()
-                .objects(putStub.testItems)
+                .objects(TestItem.class, putStub.testItems)
                 .withMapFunc(putStub.mapFunc)
                 .withPutResolver(putStub.putResolver)
-                .dontUseTransaction()
+                .useTransaction(false)
                 .prepare()
                 .executeAsBlocking();
 
@@ -58,10 +58,10 @@ public class PreparedPutObjectsTest {
 
         final Observable<PutResults<TestItem>> putResultsObservable = putStub.storIOSQLite
                 .put()
-                .objects(putStub.testItems)
+                .objects(TestItem.class, putStub.testItems)
                 .withMapFunc(putStub.mapFunc)
                 .withPutResolver(putStub.putResolver)
-                .dontUseTransaction()
+                .useTransaction(false)
                 .prepare()
                 .createObservable();
 
@@ -74,10 +74,10 @@ public class PreparedPutObjectsTest {
 
         final PutResults<TestItem> putResults = putStub.storIOSQLite
                 .put()
-                .objects(putStub.testItems)
+                .objects(TestItem.class, putStub.testItems)
                 .withMapFunc(putStub.mapFunc)
                 .withPutResolver(putStub.putResolver)
-                .useTransactionIfPossible()
+                .useTransaction(true)
                 .prepare()
                 .executeAsBlocking();
 
@@ -90,10 +90,10 @@ public class PreparedPutObjectsTest {
 
         final Observable<PutResults<TestItem>> putResultsObservable = putStub.storIOSQLite
                 .put()
-                .objects(putStub.testItems)
+                .objects(TestItem.class, putStub.testItems)
                 .withMapFunc(putStub.mapFunc)
                 .withPutResolver(putStub.putResolver)
-                .useTransactionIfPossible()
+                .useTransaction(true)
                 .prepare()
                 .createObservable();
 

--- a/storio-test-without-rxjava/src/test/java/com/pushtorefresh/storio/test_without_rxjava/sqlite/DefaultStorIOSQLiteTest.java
+++ b/storio-test-without-rxjava/src/test/java/com/pushtorefresh/storio/test_without_rxjava/sqlite/DefaultStorIOSQLiteTest.java
@@ -43,9 +43,9 @@ public class DefaultStorIOSQLiteTest {
                 .build()
                 .get()
                 .listOfObjects(Object.class)
+                .withQuery(mock(Query.class))
                 .withGetResolver(mock(GetResolver.class))
                 .withMapFunc(mock(MapFunc.class))
-                .withQuery(mock(Query.class))
                 .prepare();
     }
 
@@ -105,7 +105,7 @@ public class DefaultStorIOSQLiteTest {
                 .db(mock(SQLiteDatabase.class))
                 .build()
                 .put()
-                .objects(mock(Iterable.class))
+                .objects(Object.class, mock(Iterable.class))
                 .withPutResolver(mock(PutResolver.class))
                 .withMapFunc(mock(MapFunc.class))
                 .prepare();
@@ -118,7 +118,7 @@ public class DefaultStorIOSQLiteTest {
                 .db(mock(SQLiteDatabase.class))
                 .build()
                 .put()
-                .objects(mock(Object.class), mock(Object.class))
+                .objects(Object.class, mock(Object.class), mock(Object.class))
                 .withPutResolver(mock(PutResolver.class))
                 .withMapFunc(mock(MapFunc.class))
                 .prepare();


### PR DESCRIPTION
Part of #274 

Everything is cool, except one thing:

Manipulations with multiple items now requires explicitly setting Type of objects

@nikitin-da PTAL