### PR TITLE
Fix for thread-safety of notifications system in StorIOSQLite

### DIFF
--- a/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/BaseSubscriptionTest.java
+++ b/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/BaseSubscriptionTest.java
@@ -37,13 +37,14 @@ public abstract class BaseSubscriptionTest extends BaseTest {
             return lock.getCount() == 0;
         }
 
-        protected void onNextObtained(T obtained) {
-            T expectedItem = expected.remove();
+        protected void onNextObtained(@NonNull T obtained) {
+            final T expectedItem = expected.remove();
             assertEquals(expectedItem, obtained);
             assertTrue(lock.getCount() > 0);
             lock.countDown();
         }
 
+        @NonNull
         public abstract Subscription subscribe();
     }
 }

--- a/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/BaseTest.java
+++ b/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/BaseTest.java
@@ -61,7 +61,7 @@ public abstract class BaseTest {
     }
 
     @NonNull
-    List<User> getAllUsers() {
+    List<User> getAllUsersBlocking() {
         return storIOSQLite
                 .get()
                 .listOfObjects(User.class)
@@ -71,13 +71,13 @@ public abstract class BaseTest {
     }
 
     @NonNull
-    User putUser() {
+    User putUserBlocking() {
         final User user = TestFactory.newUser();
-        return putUser(user);
+        return putUserBlocking(user);
     }
 
     @NonNull
-    User putUser(@NonNull final User user) {
+    User putUserBlocking(@NonNull final User user) {
 
         final PutResult putResult = storIOSQLite
                 .put()
@@ -91,14 +91,13 @@ public abstract class BaseTest {
     }
 
     @NonNull
-    List<User> putUsers(final int size) {
+    List<User> putUsersBlocking(final int size) {
         final List<User> users = TestFactory.newUsers(size);
-        return putUsers(users);
+        return putUsersBlocking(users);
     }
 
     @NonNull
-    List<User> putUsers(@NonNull final List<User> users) {
-
+    List<User> putUsersBlocking(@NonNull final List<User> users) {
         final PutResults<User> putResults = storIOSQLite
                 .put()
                 .objects(User.class, users)
@@ -111,7 +110,7 @@ public abstract class BaseTest {
     }
 
     @NonNull
-    DeleteResult deleteUser(@NonNull final User user) {
+    DeleteResult deleteUserBlocking(@NonNull final User user) {
         final DeleteResult deleteResult = storIOSQLite
                 .delete()
                 .object(user)
@@ -124,7 +123,7 @@ public abstract class BaseTest {
     }
 
     @NonNull
-    DeleteResults<User> deleteUsers(@NonNull final List<User> users) {
+    DeleteResults<User> deleteUsersBlocking(@NonNull final List<User> users) {
         final DeleteResults<User> deleteResults = storIOSQLite
                 .delete()
                 .objects(User.class, users)
@@ -134,6 +133,7 @@ public abstract class BaseTest {
         for (User user : users) {
             assertTrue(deleteResults.wasDeleted(user));
         }
+
         return deleteResults;
     }
 }

--- a/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/DeleteTest.java
+++ b/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/DeleteTest.java
@@ -18,13 +18,13 @@ public class DeleteTest extends BaseTest {
 
     @Test
     public void deleteOne() {
-        final User user = putUser();
+        final User user = putUserBlocking();
 
         final Cursor cursorAfterInsert = db.query(UserTableMeta.TABLE, null, null, null, null, null, null);
         assertEquals(1, cursorAfterInsert.getCount());
         cursorAfterInsert.close();
 
-        deleteUser(user);
+        deleteUserBlocking(user);
 
         final Cursor cursorAfterDelete = db.query(UserTableMeta.TABLE, null, null, null, null, null, null);
         assertEquals(0, cursorAfterDelete.getCount());
@@ -33,7 +33,7 @@ public class DeleteTest extends BaseTest {
 
     @Test
     public void deleteCollection() {
-        final List<User> allUsers = putUsers(10);
+        final List<User> allUsers = putUsersBlocking(10);
 
         final List<User> usersToDelete = new ArrayList<User>();
 
@@ -47,7 +47,7 @@ public class DeleteTest extends BaseTest {
                 .prepare()
                 .executeAsBlocking();
 
-        final List<User> usersAfterDelete = getAllUsers();
+        final List<User> usersAfterDelete = getAllUsersBlocking();
 
         assertEquals(allUsers.size() / 2, usersAfterDelete.size());
 

--- a/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/InsertTest.java
+++ b/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/InsertTest.java
@@ -17,7 +17,7 @@ public class InsertTest extends BaseTest {
 
     @Test
     public void insertOne() {
-        final User user = putUser();
+        final User user = putUserBlocking();
 
         // why we created StorIOSQLite: nobody loves nulls
         final Cursor cursor = db.query(UserTableMeta.TABLE, null, null, null, null, null, null);
@@ -36,7 +36,7 @@ public class InsertTest extends BaseTest {
 
     @Test
     public void insertCollection() {
-        final List<User> users = putUsers(3);
+        final List<User> users = putUsersBlocking(3);
 
         // asserting that values was really inserted to db
         final Cursor cursor = db.query(UserTableMeta.TABLE, null, null, null, null, null, null);
@@ -56,9 +56,9 @@ public class InsertTest extends BaseTest {
         final User user = TestFactory.newUser();
 
         for (int i = 0; i < 2; i++) {
-            putUser(user);
+            putUserBlocking(user);
 
-            final List<User> existUsers = getAllUsers();
+            final List<User> existUsers = getAllUsersBlocking();
 
             assertNotNull(existUsers);
             assertEquals(1, existUsers.size());
@@ -67,7 +67,7 @@ public class InsertTest extends BaseTest {
             assertEquals(1, cursorAfterPut.getCount());
             cursorAfterPut.close();
 
-            deleteUser(user);
+            deleteUserBlocking(user);
 
             final Cursor cursorAfterDelete = db.query(UserTableMeta.TABLE, null, null, null, null, null, null);
             assertEquals(0, cursorAfterDelete.getCount());

--- a/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/ObserveChangesTest.java
+++ b/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/ObserveChangesTest.java
@@ -13,7 +13,6 @@ import java.util.Queue;
 
 import rx.Subscription;
 import rx.functions.Action1;
-import rx.schedulers.Schedulers;
 
 import static junit.framework.Assert.assertTrue;
 
@@ -29,7 +28,6 @@ public class ObserveChangesTest extends BaseSubscriptionTest {
         public Subscription subscribe() {
             return storIOSQLite
                     .observeChangesInTable(UserTableMeta.TABLE)
-                    .subscribeOn(Schedulers.io())
                     .subscribe(new Action1<Changes>() {
                         @Override
                         public void call(Changes changes) {
@@ -49,7 +47,7 @@ public class ObserveChangesTest extends BaseSubscriptionTest {
         final EmissionChecker emissionChecker = new EmissionChecker(expectedUsers);
         final Subscription subscription = emissionChecker.subscribe();
 
-        putUsers(users);
+        putUsersBlocking(users);
 
         assertTrue(emissionChecker.syncWait());
 
@@ -58,7 +56,7 @@ public class ObserveChangesTest extends BaseSubscriptionTest {
 
     @Test
     public void updateEmission() {
-        final List<User> users = putUsers(10);
+        final List<User> users = putUsersBlocking(10);
         final List<User> updated = new ArrayList<User>(users.size());
         for (User user : users) {
             updated.add(User.newInstance(user.id(), user.email()));
@@ -82,7 +80,7 @@ public class ObserveChangesTest extends BaseSubscriptionTest {
 
     @Test
     public void deleteEmission() {
-        final List<User> users = putUsers(10);
+        final List<User> users = putUsersBlocking(10);
 
         final Queue<Changes> expected = new LinkedList<Changes>();
         expected.add(Changes.newInstance(UserTableMeta.TABLE));
@@ -90,7 +88,7 @@ public class ObserveChangesTest extends BaseSubscriptionTest {
         final EmissionChecker emissionChecker = new EmissionChecker(expected);
         final Subscription subscription = emissionChecker.subscribe();
 
-        deleteUsers(users);
+        deleteUsersBlocking(users);
 
         assertTrue(emissionChecker.syncWait());
 

--- a/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/QueryTest.java
+++ b/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/QueryTest.java
@@ -26,14 +26,14 @@ public class QueryTest extends BaseTest {
 
     @Test
     public void queryAll() {
-        final List<User> users = putUsers(3);
-        final List<User> usersFromQuery = getAllUsers();
+        final List<User> users = putUsersBlocking(3);
+        final List<User> usersFromQuery = getAllUsersBlocking();
         assertTrue(users.equals(usersFromQuery));
     }
 
     @Test
     public void queryOneByField() {
-        final List<User> users = putUsers(3);
+        final List<User> users = putUsersBlocking(3);
 
         for (User user : users) {
             final List<User> usersFromQuery = storIOSQLite
@@ -60,7 +60,7 @@ public class QueryTest extends BaseTest {
         // Reverse sorting by email before inserting, for the purity of the experiment.
         Collections.reverse(users);
 
-        putUsers(users);
+        putUsersBlocking(users);
 
         final List<User> usersFromQueryOrdered = storIOSQLite
                 .get()
@@ -90,7 +90,7 @@ public class QueryTest extends BaseTest {
         // Sorting by email before inserting, for the purity of the experiment.
         Collections.sort(users);
 
-        putUsers(users);
+        putUsersBlocking(users);
 
         final List<User> usersFromQueryOrdered = storIOSQLite
                 .get()
@@ -115,7 +115,7 @@ public class QueryTest extends BaseTest {
 
     @Test
     public void querySingleLimit() {
-        putUsers(10);
+        putUsersBlocking(10);
 
         final int limit = 8;
         final List<User> usersFromQuery = storIOSQLite
@@ -134,7 +134,7 @@ public class QueryTest extends BaseTest {
 
     @Test
     public void queryLimitOffset() {
-        final List<User> users = putUsers(10);
+        final List<User> users = putUsersBlocking(10);
 
         final int offset = 5;
         final int limit = 3;
@@ -175,7 +175,7 @@ public class QueryTest extends BaseTest {
             users.set(i, User.newInstance(null, commonEmail));
         }
 
-        putUsers(users);
+        putUsersBlocking(users);
 
         final List<User> groupsOfUsers = storIOSQLite
                 .get()
@@ -214,7 +214,7 @@ public class QueryTest extends BaseTest {
             users.set(i, User.newInstance(null, commonEmail));
         }
 
-        putUsers(users);
+        putUsersBlocking(users);
 
         final int bigGroupThreshold = 5;
 
@@ -249,7 +249,7 @@ public class QueryTest extends BaseTest {
             users.add(User.newInstance((long) i, "same@email.com"));
         }
 
-        putUsers(users);
+        putUsersBlocking(users);
 
         final GetResolver<User> customGetResolver = new DefaultGetResolver<User>() {
             @NonNull
@@ -302,7 +302,7 @@ public class QueryTest extends BaseTest {
             users.set(i, User.newInstance(null, new String(chars)));
         }
 
-        putUsers(users);
+        putUsersBlocking(users);
 
         final List<User> usersWithLongName = new ArrayList<User>(users.size());
 
@@ -341,7 +341,7 @@ public class QueryTest extends BaseTest {
 
         final List<User> users = TestFactory.newUsers(10);
         users.add(testUser);
-        putUsers(users);
+        putUsersBlocking(users);
 
         final String query = "SELECT * FROM " + UserTableMeta.TABLE
                 + " WHERE " + UserTableMeta.COLUMN_EMAIL + " LIKE ?";
@@ -363,7 +363,7 @@ public class QueryTest extends BaseTest {
 
     @Test
     public void queryWithRawQuerySqlInjectionFail() {
-        final List<User> users = putUsers(10);
+        final List<User> users = putUsersBlocking(10);
 
         final String query = "SELECT * FROM " + UserTableMeta.TABLE
                 + " WHERE " + UserTableMeta.COLUMN_EMAIL + " LIKE ?";
@@ -379,6 +379,6 @@ public class QueryTest extends BaseTest {
                 .prepare()
                 .executeAsBlocking();
 
-        assertEquals(users, getAllUsers());
+        assertEquals(users, getAllUsersBlocking());
     }
 }


### PR DESCRIPTION
Previous implementation had problem with thread-safety, it could publish one notification several times :(

This patch fixes that, also I've added two new integration tests for notifications system of StorIOSQLite.

@nikitin-da PTAL

It should help with #336 problem and flaky tests.