### PR TITLE
Observables operate on Schedulers.io() by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,11 @@ storIOSQLite
     .build())
   .prepare()
   .createObservable() // Get Result as rx.Observable and subscribe to further updates of tables from Query!
-  .subscribeOn(Schedulers.io())
-  .observeOn(AndroidSchedulers.mainThread())
-  .subscribe(new Action1<List<Tweet>>() { // don't forget to unsubscribe please
+  .observeOn(AndroidSchedulers.mainThread()) // Operates on Schedulers.io()
+  .subscribe(new Action1<List<Tweet>>() { // Please don't forget to unsubscribe
   	@Override public void call(List<Tweet> tweets) {
-  	  // will be called with first result and then after each change of tables from Query
-  	  // several changes in transaction -> one notification
+  	  // Will be called with first result and then after each change of tables from Query
+  	  // Several changes in transaction -> one notification
   	  adapter.setData(tweets);
   	}
   });
@@ -219,6 +218,10 @@ All `Query` objects are immutable, you can share them safely.
 You may notice that each Operation (Get, Put, Delete) should be prepared with `prepare()`. `StorIO` has an entity called `PreparedOperation<T>`, and you can use them to perform group execution of several Prepared Operations or provide `PreparedOperation<T>` as a return type of your API (for example in Model layer) and client will decide how to execute it: `executeAsBlocking()` or `createObservable()`. Also, Prepared Operations might be useful for ORMs based on `StorIO`.
 
 You can customize behavior of every Operation via `Resolvers`: `GetResolver`, `PutResolver`, `DeleteResolver`.
+
+####Rx Support Design
+Every Operation can be executed as rx.Observable. Get Operations will be automatically subscribed to the updates of the data.
+Every Observable runs on `Schedulers.io()` by default, currently we don't offer overloads to pass your `Scheduler`, feel free to send PRs!
 
 ----
 **Made with love** in [Pushtorefresh.com](https://pushtorefresh.com) by [@artem_zin](https://twitter.com/artem_zin) and [@nikitin-da](https://github.com/nikitin-da)

--- a/docs/StorIOSQLite.md
+++ b/docs/StorIOSQLite.md
@@ -53,9 +53,8 @@ storIOSQLite
     .build())
   .prepare()
   .createObservable() // Get Result as rx.Observable and subscribe to further updates of tables from Query!
-  .subscribeOn(Schedulers.io())
-  .observeOn(AndroidSchedulers.mainThread())
-  .subscribe(new Action1<List<Tweet>>() { // don't forget to unsubscribe please
+  .observeOn(AndroidSchedulers.mainThread()) // Operates on Schedulers.io()
+  .subscribe(new Action1<List<Tweet>>() { // Please don't forget to unsubscribe
     @Override public void call(List<Tweet> tweets) {
       // will be called with first result and then after each change of tables from Query
       // several changes in transaction -> one notification

--- a/storio-common/src/main/java/com/pushtorefresh/storio/operation/group/PreparedGroupOperation.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio/operation/group/PreparedGroupOperation.java
@@ -10,13 +10,18 @@ import java.util.List;
 import java.util.Map;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
+
+import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
 
 /**
- * Prepared Group Operation for StorIO implementations
+ * Prepared Group Operation for StorIO implementations.
  * <p/>
- * Allows group execution of any combination of {@link PreparedOperation}
+ * Allows group execution of any combination of {@link PreparedOperation}.
  * <p/>
- * And yes, you can execute {@link PreparedGroupOperation} as part of {@link PreparedGroupOperation} since it implements {@link PreparedOperation} :)
+ * And yes, you can execute {@link PreparedGroupOperation}
+ * as part of {@link PreparedGroupOperation}
+ * since it implements {@link PreparedOperation} :).
  */
 public class PreparedGroupOperation implements PreparedOperation<GroupOperationResults> {
 
@@ -28,9 +33,9 @@ public class PreparedGroupOperation implements PreparedOperation<GroupOperationR
     }
 
     /**
-     * Executes Group Operation immediately in current thread
+     * Executes Group Operation immediately in current thread.
      *
-     * @return non-null results of Group Operation
+     * @return non-null result of Group Operation.
      */
     @NonNull
     @Override
@@ -46,13 +51,26 @@ public class PreparedGroupOperation implements PreparedOperation<GroupOperationR
     }
 
     /**
-     * Creates an {@link Observable} which will emit results of Group Operation
+     * Creates {@link Observable} which will perform Group Operation and send result to observer.
+     * <p>
+     * Returned {@link Observable} will be "Cold Observable", which means that it performs
+     * Group Operation only after subscribing to it. Also, it emits the result once.
      *
-     * @return non-null {@link Observable} which will emit non-null results of Group Operation
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>Operates on {@link Schedulers#io()}.</dd>
+     * </dl>
+     *
+     * @return non-null {@link Observable} which will perform Group Operation.
+     * and send result to observer.
      */
     @NonNull
     @Override
     public Observable<GroupOperationResults> createObservable() {
-        return Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this));
+        throwExceptionIfRxJavaIsNotAvailable("createObservable()");
+
+        return Observable
+                .create(OnSubscribeExecuteAsBlocking.newInstance(this))
+                .subscribeOn(Schedulers.io());
     }
 }

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/delete/PreparedDeleteByQuery.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/delete/PreparedDeleteByQuery.java
@@ -8,6 +8,7 @@ import com.pushtorefresh.storio.contentresolver.query.DeleteQuery;
 import com.pushtorefresh.storio.operation.internal.OnSubscribeExecuteAsBlocking;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
@@ -39,13 +40,13 @@ public final class PreparedDeleteByQuery extends PreparedDelete<DeleteQuery, Del
 
     /**
      * Creates {@link Observable} which will perform Delete Operation and send result to observer.
-     * <p>
+     * <p/>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * delete only after subscribing to it. Also, it emits the result once.
-     *
+     * <p/>
      * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>Does not operate by default on a particular {@link rx.Scheduler}.</dd>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
      *
      * @return non-null {@link Observable} which will perform Delete Operation.
@@ -55,7 +56,10 @@ public final class PreparedDeleteByQuery extends PreparedDelete<DeleteQuery, Del
     @Override
     public Observable<DeleteResult> createObservable() {
         throwExceptionIfRxJavaIsNotAvailable("createObservable()");
-        return Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this));
+
+        return Observable
+                .create(OnSubscribeExecuteAsBlocking.newInstance(this))
+                .subscribeOn(Schedulers.io());
     }
 
     /**
@@ -96,7 +100,7 @@ public final class PreparedDeleteByQuery extends PreparedDelete<DeleteQuery, Del
         /**
          * Optional: Specifies resolver for Delete Operation.
          * Allows you to customise behavior of Delete Operation.
-         * <p>
+         * <p/>
          * If no value will be set, builder will use Delete Resolver
          * that simply redirects query to {@link StorIOContentResolver}.
          *

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/delete/PreparedDeleteObject.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/delete/PreparedDeleteObject.java
@@ -7,6 +7,7 @@ import com.pushtorefresh.storio.contentresolver.StorIOContentResolver;
 import com.pushtorefresh.storio.operation.internal.OnSubscribeExecuteAsBlocking;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
@@ -46,7 +47,7 @@ public final class PreparedDeleteObject<T> extends PreparedDelete<T, DeleteResul
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>Does not operate by default on a particular {@link rx.Scheduler}.</dd>
+     *  <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
      *
      * @return non-null {@link Observable} which will perform Delete Operation.
@@ -56,7 +57,10 @@ public final class PreparedDeleteObject<T> extends PreparedDelete<T, DeleteResul
     @Override
     public Observable<DeleteResult> createObservable() {
         throwExceptionIfRxJavaIsNotAvailable("createObservable()");
-        return Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this));
+
+        return Observable
+                .create(OnSubscribeExecuteAsBlocking.newInstance(this))
+                .subscribeOn(Schedulers.io());
     }
 
     /**

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/delete/PreparedDeleteObjects.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/delete/PreparedDeleteObjects.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
@@ -50,13 +51,13 @@ public final class PreparedDeleteObjects<T> extends PreparedDelete<T, DeleteResu
 
     /**
      * Creates {@link Observable} which will perform Delete Operation and send result to observer.
-     * <p>
+     * <p/>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * delete only after subscribing to it. Also, it emits the result once.
-     *
+     * <p/>
      * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>Does not operate by default on a particular {@link rx.Scheduler}.</dd>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
      *
      * @return non-null {@link Observable} which will perform Delete Operation.
@@ -66,7 +67,10 @@ public final class PreparedDeleteObjects<T> extends PreparedDelete<T, DeleteResu
     @Override
     public Observable<DeleteResults<T>> createObservable() {
         throwExceptionIfRxJavaIsNotAvailable("createObservable()");
-        return Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this));
+
+        return Observable
+                .create(OnSubscribeExecuteAsBlocking.newInstance(this))
+                .subscribeOn(Schedulers.io());
     }
 
     /**

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/get/PreparedGetCursor.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/get/PreparedGetCursor.java
@@ -9,6 +9,7 @@ import com.pushtorefresh.storio.contentresolver.query.Query;
 import com.pushtorefresh.storio.operation.internal.MapSomethingToExecuteAsBlocking;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
@@ -42,14 +43,14 @@ public final class PreparedGetCursor extends PreparedGet<Cursor, Cursor> {
     /**
      * Creates "Hot" {@link Observable} which will be subscribed to changes of {@link #query} Uri
      * and will emit result each time change occurs.
-     * <p>
-     * First result will be emitted immediately,
+     * <p/>
+     * First result will be emitted immediately after subscription,
      * other emissions will occur only if changes of {@link #query} Uri will occur.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>Does not operate by default on a particular {@link rx.Scheduler}.</dd>
+     * <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
-     * <p>
+     * <p/>
      * Please don't forget to unsubscribe from this {@link Observable} because
      * it's "Hot" and endless.
      *
@@ -64,12 +65,13 @@ public final class PreparedGetCursor extends PreparedGet<Cursor, Cursor> {
         return storIOContentResolver
                 .observeChangesOfUri(query.uri()) // each change triggers executeAsBlocking
                 .map(MapSomethingToExecuteAsBlocking.newInstance(this))
-                .startWith(executeAsBlocking()); // start stream with first query result
+                .startWith(executeAsBlocking())  // start stream with first query result
+                .subscribeOn(Schedulers.io());
     }
 
     /**
      * Builder for {@link PreparedGetCursor}.
-     * <p>
+     * <p/>
      * Required: You should specify query see {@link #withQuery(Query)}.
      */
     public static final class Builder {
@@ -123,7 +125,7 @@ public final class PreparedGetCursor extends PreparedGet<Cursor, Cursor> {
         /**
          * Optional: Specifies {@link GetResolver} for Get Operation
          * which allows you to customize behavior of Get Operation.
-         * <p>
+         * <p/>
          * If no value will be set, builder will use resolver that
          * simply redirects query to {@link StorIOContentResolver}.
          *

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/get/PreparedGetListOfObjects.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/get/PreparedGetListOfObjects.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
@@ -66,15 +67,15 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<T, List<T>> {
     /**
      * Creates "Hot" {@link Observable} which will be subscribed to changes of {@link #query} Uri
      * and will emit result each time change occurs.
-     * <p>
-     * First result will be emitted immediately,
+     * <p/>
+     * First result will be emitted immediately after subscription,
      * other emissions will occur only if changes of {@link #query} Uri will occur.
-     * <p>
+     * <p/>
      * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>Does not operate by default on a particular {@link rx.Scheduler}.</dd>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
-     * <p>
+     * <p/>
      * Please don't forget to unsubscribe from this {@link Observable}
      * because it's "Hot" and endless.
      *
@@ -89,7 +90,8 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<T, List<T>> {
         return storIOContentResolver
                 .observeChangesOfUri(query.uri()) // each change triggers executeAsBlocking
                 .map(MapSomethingToExecuteAsBlocking.newInstance(this))
-                .startWith(executeAsBlocking());  // start stream with first query result
+                .startWith(executeAsBlocking())   // start stream with first query result
+                .subscribeOn(Schedulers.io());
     }
 
     /**
@@ -150,7 +152,7 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<T, List<T>> {
         /**
          * Optional: Specifies {@link GetResolver} for Get Operation
          * which allows you to customize behavior of Get Operation.
-         * <p>
+         * <p/>
          * Can be set via {@link ContentResolverTypeMapping},
          * If value is not set via {@link ContentResolverTypeMapping} -> exception will be thrown.
          *

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/put/PreparedPutContentValues.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/put/PreparedPutContentValues.java
@@ -7,6 +7,7 @@ import com.pushtorefresh.storio.contentresolver.StorIOContentResolver;
 import com.pushtorefresh.storio.operation.internal.OnSubscribeExecuteAsBlocking;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
@@ -37,13 +38,13 @@ public final class PreparedPutContentValues extends PreparedPut<ContentValues, P
 
     /**
      * Creates {@link Observable} which will perform Put Operation and send result to observer.
-     * <p>
+     * <p/>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * put only after subscribing to it. Also, it emits the result once.
-     * <p>
+     * <p/>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>Does not operate by default on a particular {@link rx.Scheduler}.</dd>
+     * <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
      *
      * @return non-null {@link Observable} which will perform Put Operation.
@@ -53,12 +54,15 @@ public final class PreparedPutContentValues extends PreparedPut<ContentValues, P
     @Override
     public Observable<PutResult> createObservable() {
         throwExceptionIfRxJavaIsNotAvailable("createObservable()");
-        return Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this));
+
+        return Observable
+                .create(OnSubscribeExecuteAsBlocking.newInstance(this))
+                .subscribeOn(Schedulers.io());
     }
 
     /**
      * Builder for {@link PreparedPutContentValues}.
-     * <p>
+     * <p/>
      * Required: You should specify put resolver see {@link #withPutResolver(PutResolver)}.
      */
     public static final class Builder {

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/put/PreparedPutContentValuesIterable.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/put/PreparedPutContentValuesIterable.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
@@ -50,13 +51,13 @@ public final class PreparedPutContentValuesIterable extends PreparedPut<ContentV
 
     /**
      * Creates {@link Observable} which will perform Put Operation and send result to observer.
-     * <p>
+     * <p/>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * put only after subscribing to it. Also, it emits the result once.
-     *
+     * <p/>
      * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>Does not operate by default on a particular {@link rx.Scheduler}.</dd>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
      *
      * @return non-null {@link Observable} which will perform Put Operation.
@@ -66,7 +67,10 @@ public final class PreparedPutContentValuesIterable extends PreparedPut<ContentV
     @Override
     public Observable<PutResults<ContentValues>> createObservable() {
         throwExceptionIfRxJavaIsNotAvailable("createObservable()");
-        return Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this));
+
+        return Observable
+                .create(OnSubscribeExecuteAsBlocking.newInstance(this))
+                .subscribeOn(Schedulers.io());
     }
 
     /**

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/put/PreparedPutObject.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/put/PreparedPutObject.java
@@ -8,6 +8,7 @@ import com.pushtorefresh.storio.contentresolver.StorIOContentResolver;
 import com.pushtorefresh.storio.operation.internal.OnSubscribeExecuteAsBlocking;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
@@ -43,13 +44,13 @@ public final class PreparedPutObject<T> extends PreparedPut<T, PutResult> {
 
     /**
      * Creates {@link Observable} which will perform Put Operation and send result to observer.
-     * <p>
+     * <p/>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * put only after subscribing to it. Also, it emits the result once.
-     *
+     * <p/>
      * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>Does not operate by default on a particular {@link rx.Scheduler}.</dd>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
      *
      * @return non-null {@link Observable} which will perform Put Operation.
@@ -59,7 +60,10 @@ public final class PreparedPutObject<T> extends PreparedPut<T, PutResult> {
     @Override
     public Observable<PutResult> createObservable() {
         throwExceptionIfRxJavaIsNotAvailable("createObservable()");
-        return Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this));
+
+        return Observable
+                .create(OnSubscribeExecuteAsBlocking.newInstance(this))
+                .subscribeOn(Schedulers.io());
     }
 
     /**

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/put/PreparedPutObjects.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/put/PreparedPutObjects.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
@@ -51,13 +52,13 @@ public final class PreparedPutObjects<T> extends PreparedPut<T, PutResults<T>> {
 
     /**
      * Creates {@link Observable} which will perform Put Operation and send result to observer.
-     * <p>
+     * <p/>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * put only after subscribing to it. Also, it emits the result once.
-     *
+     * <p/>
      * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>Does not operate by default on a particular {@link rx.Scheduler}.</dd>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
      *
      * @return non-null {@link Observable} which will perform Put Operation.
@@ -67,7 +68,10 @@ public final class PreparedPutObjects<T> extends PreparedPut<T, PutResults<T>> {
     @Override
     public Observable<PutResults<T>> createObservable() {
         throwExceptionIfRxJavaIsNotAvailable("createObservable()");
-        return Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this));
+
+        return Observable
+                .create(OnSubscribeExecuteAsBlocking.newInstance(this))
+                .subscribeOn(Schedulers.io());
     }
 
     /**

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/put/PreparedPutContentValues.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/put/PreparedPutContentValues.java
@@ -8,6 +8,7 @@ import com.pushtorefresh.storio.sqlite.Changes;
 import com.pushtorefresh.storio.sqlite.StorIOSQLite;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
@@ -40,13 +41,13 @@ public final class PreparedPutContentValues extends PreparedPut<ContentValues, P
 
     /**
      * Creates {@link Observable} which will perform Put Operation and send result to observer.
-     * <p>
+     * <p/>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * put only after subscribing to it. Also, it emits the result once.
-     *
+     * <p/>
      * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>Does not operate by default on a particular {@link rx.Scheduler}.</dd>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
      *
      * @return non-null {@link Observable} which will perform Put Operation.
@@ -56,7 +57,10 @@ public final class PreparedPutContentValues extends PreparedPut<ContentValues, P
     @Override
     public Observable<PutResult> createObservable() {
         throwExceptionIfRxJavaIsNotAvailable("createObservable()");
-        return Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this));
+
+        return Observable
+                .create(OnSubscribeExecuteAsBlocking.newInstance(this))
+                .subscribeOn(Schedulers.io());
     }
 
     /**

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/put/PreparedPutContentValuesIterable.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/put/PreparedPutContentValuesIterable.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
@@ -36,9 +37,9 @@ public final class PreparedPutContentValuesIterable extends PreparedPut<ContentV
     }
 
     /**
-     * Executes Put Operation immediately in current thread
+     * Executes Put Operation immediately in current thread.
      *
-     * @return non-null results of Put Operation
+     * @return non-null results of Put Operation.
      */
     @NonNull
     @Override
@@ -87,15 +88,27 @@ public final class PreparedPutContentValuesIterable extends PreparedPut<ContentV
     }
 
     /**
-     * Creates {@link Observable} which will perform Put Operation and send results to observer
+     * Creates {@link Observable} which will perform Put Operation and send result to observer.
+     * <p/>
+     * Returned {@link Observable} will be "Cold Observable", which means that it performs
+     * put only after subscribing to it. Also, it emits the result once.
+     * <p/>
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>Operates on {@link Schedulers#io()}.</dd>
+     * </dl>
      *
-     * @return non-null {@link Observable} which will perform Put Operation and send results to observer
+     * @return non-null {@link Observable} which will perform Put Operation.
+     * and send result to observer.
      */
     @NonNull
     @Override
     public Observable<PutResults<ContentValues>> createObservable() {
         throwExceptionIfRxJavaIsNotAvailable("createObservable()");
-        return Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this));
+
+        return Observable
+                .create(OnSubscribeExecuteAsBlocking.newInstance(this))
+                .subscribeOn(Schedulers.io());
     }
 
     /**

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/put/PreparedPutObject.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/put/PreparedPutObject.java
@@ -2,15 +2,16 @@ package com.pushtorefresh.storio.sqlite.operation.put;
 
 import android.support.annotation.NonNull;
 
-import com.pushtorefresh.storio.internal.Environment;
 import com.pushtorefresh.storio.operation.internal.OnSubscribeExecuteAsBlocking;
 import com.pushtorefresh.storio.sqlite.Changes;
 import com.pushtorefresh.storio.sqlite.SQLiteTypeMapping;
 import com.pushtorefresh.storio.sqlite.StorIOSQLite;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
+import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
 
 /**
  * Prepared Put Operation for {@link StorIOSQLite}.
@@ -43,13 +44,13 @@ public final class PreparedPutObject<T> extends PreparedPut<T, PutResult> {
 
     /**
      * Creates {@link Observable} which will perform Put Operation and send result to observer.
-     * <p>
+     * <p/>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * put only after subscribing to it. Also, it emits the result once.
-     *
+     * <p/>
      * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>Does not operate by default on a particular {@link rx.Scheduler}.</dd>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
      *
      * @return non-null {@link Observable} which will perform Put Operation.
@@ -57,8 +58,11 @@ public final class PreparedPutObject<T> extends PreparedPut<T, PutResult> {
      */
     @NonNull
     public Observable<PutResult> createObservable() {
-        Environment.throwExceptionIfRxJavaIsNotAvailable("createObservable()");
-        return Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this));
+        throwExceptionIfRxJavaIsNotAvailable("createObservable()");
+
+        return Observable
+                .create(OnSubscribeExecuteAsBlocking.newInstance(this))
+                .subscribeOn(Schedulers.io());
     }
 
     /**
@@ -84,7 +88,7 @@ public final class PreparedPutObject<T> extends PreparedPut<T, PutResult> {
         /**
          * Optional: Specifies {@link PutResolver} for Put Operation
          * which allows you to customize behavior of Put Operation.
-         * <p>
+         * <p/>
          * Can be set via {@link SQLiteTypeMapping}
          * If it's not set via {@link SQLiteTypeMapping} or explicitly -> exception will be thrown.
          *

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/put/PreparedPutObjects.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/put/PreparedPutObjects.java
@@ -2,7 +2,6 @@ package com.pushtorefresh.storio.sqlite.operation.put;
 
 import android.support.annotation.NonNull;
 
-import com.pushtorefresh.storio.internal.Environment;
 import com.pushtorefresh.storio.operation.internal.OnSubscribeExecuteAsBlocking;
 import com.pushtorefresh.storio.sqlite.Changes;
 import com.pushtorefresh.storio.sqlite.SQLiteTypeMapping;
@@ -14,8 +13,10 @@ import java.util.Map;
 import java.util.Set;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
+import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
 
 public final class PreparedPutObjects<T> extends PreparedPut<T, PutResults<T>> {
 
@@ -34,9 +35,9 @@ public final class PreparedPutObjects<T> extends PreparedPut<T, PutResults<T>> {
     }
 
     /**
-     * Executes Put Operation immediately in current thread
+     * Executes Put Operation immediately in current thread.
      *
-     * @return non-null results of Put Operation
+     * @return non-null results of Put Operation.
      */
     @NonNull
     @Override
@@ -85,15 +86,27 @@ public final class PreparedPutObjects<T> extends PreparedPut<T, PutResults<T>> {
     }
 
     /**
-     * Creates {@link Observable} which will perform Put Operation and send results to observer
+     * Creates {@link Observable} which will perform Put Operation and send result to observer.
+     * <p/>
+     * Returned {@link Observable} will be "Cold Observable", which means that it performs
+     * put only after subscribing to it. Also, it emits the result once.
+     * <p/>
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>Operates on {@link Schedulers#io()}.</dd>
+     * </dl>
      *
-     * @return non-null {@link Observable} which will perform Put Operation and send results to observer
+     * @return non-null {@link Observable} which will perform Put Operation.
+     * and send result to observer.
      */
     @NonNull
     @Override
     public Observable<PutResults<T>> createObservable() {
-        Environment.throwExceptionIfRxJavaIsNotAvailable("createObservable()");
-        return Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this));
+        throwExceptionIfRxJavaIsNotAvailable("createObservable()");
+
+        return Observable
+                .create(OnSubscribeExecuteAsBlocking.newInstance(this))
+                .subscribeOn(Schedulers.io());
     }
 
     /**


### PR DESCRIPTION
Closes #335.

Now all `rx.Observable` operate on `Schedulers.io()`, for 1.0.0 we won't provide overloads to pass custom `rx.Scheduler`.

@nikitin-da PTAL

