### PR TITLE
StorIOSQLite now implements Closeable and all work with database goes through SQLiteOpenHelper

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Cursor cursor = storIOSQLite
 
 ```java
 StorIOSQLite storIOSQLite = new DefaultStorIOSQLite.Builder()
-  .db(someSQLiteDatabase)
+  .sqliteOpenHelper(someSQLiteOpenHelper)
   .addTypeMapping(Tweet.class, new SQLiteTypeMapping.Builder<Tweet>()
     .putResolver(new TweetPutResolver()) // object that knows how to perform Put Operation (insert or update)
     .getResolver(new TweetGetResolver()) // object that knows how to perform Get Operation
@@ -169,7 +169,7 @@ You just need to apply them:
 
 ```java
 StorIOSQLite storIOSQLite = new DefaultStorIOSQLite.Builder()
-  .db(someSQLiteDatabase)
+  .sqliteOpenHelper(someSQLiteOpenHelper
   .addTypeMapping(Tweet.class, new SQLiteTypeMapping.Builder<Tweet>()
     .putResolver(new TweetStorIOSQLitePutResolver()) // object that knows how to perform Put Operation (insert or update)
     .getResolver(new TweetStorIOSQLiteGetResolver()) // object that knows how to perform Get Operation

--- a/docs/StorIOSQLite.md
+++ b/docs/StorIOSQLite.md
@@ -4,7 +4,7 @@
 
 ```java
 StorIOSQLite storIOSQLite = new DefaultStorIOSQLite.Builder()
-  .sqliteOpenHelper(yourSqliteOpenHelper) // or .db(db)
+  .sqliteOpenHelper(yourSqliteOpenHelper)
   .addTypeMapping(SomeType.class, typeMapping) // required for object mapping
   .build();
 ```
@@ -248,7 +248,7 @@ Several things about `ExecSql`:
 
 ```java
 StorIOSQLite storIOSQLite = new DefaultStorIOSQLite.Builder()
-  .db(someSQLiteDatabase)
+  .sqliteOpenHelper(someSQLiteOpenHelper
   .addTypeMapping(Tweet.class, new SQLiteTypeMapping.Builder<Tweet>()
     .putResolver(new TweetPutResolver()) // object that knows how to perform Put Operation (insert or update)
     .getResolver(new TweetGetResolver()) // object that knows how to perform Get Operation
@@ -300,7 +300,7 @@ You just need to apply them:
 
 ```java
 StorIOSQLite storIOSQLite = new DefaultStorIOSQLite.Builder()
-  .db(someSQLiteDatabase)
+  .sqliteOpenHelper(someSQLiteOpenHelper
   .addTypeMapping(Tweet.class, new SQLiteTypeMapping.Builder<Tweet>()
     .putResolver(new TweetStorIOSQLitePutResolver()) // object that knows how to perform Put Operation (insert or update)
     .getResolver(new TweetStorIOSQLiteGetResolver()) // object that knows how to perform Get Operation

--- a/storio-sample-app/src/main/java/com/pushtorefresh/storio/sample/db/DbModule.java
+++ b/storio-sample-app/src/main/java/com/pushtorefresh/storio/sample/db/DbModule.java
@@ -1,7 +1,7 @@
 package com.pushtorefresh.storio.sample.db;
 
 import android.content.Context;
-import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
 import android.support.annotation.NonNull;
 
 import com.pushtorefresh.storio.sample.db.entity.Tweet;
@@ -23,9 +23,9 @@ public class DbModule {
     @Provides
     @NonNull
     @Singleton
-    public StorIOSQLite provideStorIOSQLite(@NonNull SQLiteDatabase db) {
+    public StorIOSQLite provideStorIOSQLite(@NonNull SQLiteOpenHelper sqLiteOpenHelper) {
         return new DefaultStorIOSQLite.Builder()
-                .db(db)
+                .sqliteOpenHelper(sqLiteOpenHelper)
                 .addTypeMapping(Tweet.class, new SQLiteTypeMapping.Builder<Tweet>()
                         .putResolver(new TweetStorIOSQLitePutResolver())
                         .getResolver(new TweetStorIOSQLiteGetResolver())
@@ -37,8 +37,7 @@ public class DbModule {
     @Provides
     @NonNull
     @Singleton
-    public SQLiteDatabase provideSQLiteDatabase(@NonNull Context context) {
-        return new DbOpenHelper(context)
-                .getWritableDatabase();
+    public SQLiteOpenHelper provideSQSqLiteOpenHelper(@NonNull Context context) {
+        return new DbOpenHelper(context);
     }
 }

--- a/storio-sample-app/src/main/java/com/pushtorefresh/storio/sample/provider/SampleContentProvider.java
+++ b/storio-sample-app/src/main/java/com/pushtorefresh/storio/sample/provider/SampleContentProvider.java
@@ -5,7 +5,7 @@ import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.UriMatcher;
 import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
 import android.net.Uri;
 
 import com.pushtorefresh.storio.sample.SampleApp;
@@ -27,7 +27,7 @@ public class SampleContentProvider extends ContentProvider {
     }
 
     @Inject
-    SQLiteDatabase db;
+    SQLiteOpenHelper sqLiteOpenHelper;
 
     /**
      * {@inheritDoc}
@@ -42,15 +42,17 @@ public class SampleContentProvider extends ContentProvider {
     public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
         switch (URI_MATCHER.match(uri)) {
             case URI_MATCHER_CODE_TWEETS:
-                return db.query(
-                        TweetTableMeta.TABLE,
-                        projection,
-                        selection,
-                        selectionArgs,
-                        null,
-                        null,
-                        sortOrder
-                );
+                return sqLiteOpenHelper
+                        .getReadableDatabase()
+                        .query(
+                                TweetTableMeta.TABLE,
+                                projection,
+                                selection,
+                                selectionArgs,
+                                null,
+                                null,
+                                sortOrder
+                        );
 
             default:
                 return null;
@@ -66,11 +68,13 @@ public class SampleContentProvider extends ContentProvider {
     public Uri insert(Uri uri, ContentValues values) {
         switch (URI_MATCHER.match(uri)) {
             case URI_MATCHER_CODE_TWEETS:
-                final long insertedId = db.insert(
-                        TweetTableMeta.TABLE,
-                        null,
-                        values
-                );
+                final long insertedId = sqLiteOpenHelper
+                        .getWritableDatabase()
+                        .insert(
+                                TweetTableMeta.TABLE,
+                                null,
+                                values
+                        );
 
                 return ContentUris.withAppendedId(uri, insertedId);
         }
@@ -82,11 +86,13 @@ public class SampleContentProvider extends ContentProvider {
     public int delete(Uri uri, String selection, String[] selectionArgs) {
         switch (URI_MATCHER.match(uri)) {
             case URI_MATCHER_CODE_TWEETS:
-                return db.delete(
-                        TweetTableMeta.TABLE,
-                        selection,
-                        selectionArgs
-                );
+                return sqLiteOpenHelper
+                        .getWritableDatabase()
+                        .delete(
+                                TweetTableMeta.TABLE,
+                                selection,
+                                selectionArgs
+                        );
         }
 
         return 0;
@@ -96,12 +102,14 @@ public class SampleContentProvider extends ContentProvider {
     public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
         switch (URI_MATCHER.match(uri)) {
             case URI_MATCHER_CODE_TWEETS:
-                return db.update(
-                        TweetTableMeta.TABLE,
-                        values,
-                        selection,
-                        selectionArgs
-                );
+                return sqLiteOpenHelper
+                        .getWritableDatabase()
+                        .update(
+                                TweetTableMeta.TABLE,
+                                values,
+                                selection,
+                                selectionArgs
+                        );
         }
 
         return 0;

--- a/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/BaseTest.java
+++ b/storio-sqlite/src/androidTest/java/com/pushtorefresh/storio/sqlite/impl/BaseTest.java
@@ -1,6 +1,7 @@
 package com.pushtorefresh.storio.sqlite.impl;
 
 import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
 import android.support.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 
@@ -25,15 +26,19 @@ public abstract class BaseTest {
     protected StorIOSQLite storIOSQLite;
 
     @NonNull
+    protected SQLiteOpenHelper sqLiteOpenHelper;
+
+    @NonNull
     protected SQLiteDatabase db;
 
     @Before
     public void setUp() throws Exception {
-        db = new TestSQLiteOpenHelper(InstrumentationRegistry.getContext())
-                .getWritableDatabase();
+        sqLiteOpenHelper = new TestSQLiteOpenHelper(InstrumentationRegistry.getContext());
+
+        db = sqLiteOpenHelper.getWritableDatabase();
 
         storIOSQLite = new DefaultStorIOSQLite.Builder()
-                .db(db)
+                .sqliteOpenHelper(sqLiteOpenHelper)
                 .addTypeMapping(User.class, new SQLiteTypeMapping.Builder<User>()
                         .putResolver(UserTableMeta.PUT_RESOLVER)
                         .getResolver(UserTableMeta.GET_RESOLVER)

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/StorIOSQLite.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/StorIOSQLite.java
@@ -15,6 +15,7 @@ import com.pushtorefresh.storio.sqlite.query.Query;
 import com.pushtorefresh.storio.sqlite.query.RawQuery;
 import com.pushtorefresh.storio.sqlite.query.UpdateQuery;
 
+import java.io.Closeable;
 import java.util.Collections;
 import java.util.Set;
 
@@ -26,7 +27,7 @@ import rx.Observable;
  * It's an abstract class instead of interface because we want to have ability to add some
  * changes without breaking existing implementations.
  */
-public abstract class StorIOSQLite {
+public abstract class StorIOSQLite implements Closeable {
 
     /**
      * Prepares "Execute SQL" Operation for {@link StorIOSQLite}.

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/design/DesignTestStorIOSQLite.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/design/DesignTestStorIOSQLite.java
@@ -18,6 +18,7 @@ import com.pushtorefresh.storio.sqlite.query.Query;
 import com.pushtorefresh.storio.sqlite.query.RawQuery;
 import com.pushtorefresh.storio.sqlite.query.UpdateQuery;
 
+import java.io.IOException;
 import java.util.Set;
 
 import rx.Observable;
@@ -123,5 +124,10 @@ class DesignTestStorIOSQLite extends StorIOSQLite {
     @Override
     public Internal internal() {
         return internal;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // no impl
     }
 }

--- a/storio-test-without-rxjava/src/test/java/com/pushtorefresh/storio/test_without_rxjava/sqlite/DefaultStorIOSQLiteTest.java
+++ b/storio-test-without-rxjava/src/test/java/com/pushtorefresh/storio/test_without_rxjava/sqlite/DefaultStorIOSQLiteTest.java
@@ -1,7 +1,7 @@
 package com.pushtorefresh.storio.test_without_rxjava.sqlite;
 
 import android.content.ContentValues;
-import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
 
 import com.pushtorefresh.storio.sqlite.impl.DefaultStorIOSQLite;
 import com.pushtorefresh.storio.sqlite.operation.get.GetResolver;
@@ -18,7 +18,7 @@ public class DefaultStorIOSQLiteTest {
     public void instantiateWithoutRxJava() {
         // Should not fail
         new DefaultStorIOSQLite.Builder()
-                .db(mock(SQLiteDatabase.class))
+                .sqliteOpenHelper(mock(SQLiteOpenHelper.class))
                 .build();
     }
 
@@ -26,7 +26,7 @@ public class DefaultStorIOSQLiteTest {
     @Test
     public void instantiateGetCursor() {
         new DefaultStorIOSQLite.Builder()
-                .db(mock(SQLiteDatabase.class))
+                .sqliteOpenHelper(mock(SQLiteOpenHelper.class))
                 .build()
                 .get()
                 .cursor()
@@ -41,7 +41,7 @@ public class DefaultStorIOSQLiteTest {
     @Test
     public void instantiateGetListOfObjects() {
         new DefaultStorIOSQLite.Builder()
-                .db(mock(SQLiteDatabase.class))
+                .sqliteOpenHelper(mock(SQLiteOpenHelper.class))
                 .build()
                 .get()
                 .listOfObjects(Object.class)
@@ -56,7 +56,7 @@ public class DefaultStorIOSQLiteTest {
     @Test
     public void instantiatePutObject() {
         new DefaultStorIOSQLite.Builder()
-                .db(mock(SQLiteDatabase.class))
+                .sqliteOpenHelper(mock(SQLiteOpenHelper.class))
                 .build()
                 .put()
                 .object(mock(Object.class))
@@ -68,7 +68,7 @@ public class DefaultStorIOSQLiteTest {
     @Test
     public void instantiatePutObjectsIterable() {
         new DefaultStorIOSQLite.Builder()
-                .db(mock(SQLiteDatabase.class))
+                .sqliteOpenHelper(mock(SQLiteOpenHelper.class))
                 .build()
                 .put()
                 .objects(Object.class, mock(Iterable.class))
@@ -80,7 +80,7 @@ public class DefaultStorIOSQLiteTest {
     @Test
     public void instantiatePutObjectsVarArgs() {
         new DefaultStorIOSQLite.Builder()
-                .db(mock(SQLiteDatabase.class))
+                .sqliteOpenHelper(mock(SQLiteOpenHelper.class))
                 .build()
                 .put()
                 .objects(Object.class, mock(Object.class), mock(Object.class))
@@ -92,7 +92,7 @@ public class DefaultStorIOSQLiteTest {
     @Test
     public void instantiatePutContentValues() {
         new DefaultStorIOSQLite.Builder()
-                .db(mock(SQLiteDatabase.class))
+                .sqliteOpenHelper(mock(SQLiteOpenHelper.class))
                 .build()
                 .put()
                 .contentValues(mock(ContentValues.class))
@@ -104,7 +104,7 @@ public class DefaultStorIOSQLiteTest {
     @Test
     public void instantiatePutContentValuesIterable() {
         new DefaultStorIOSQLite.Builder()
-                .db(mock(SQLiteDatabase.class))
+                .sqliteOpenHelper(mock(SQLiteOpenHelper.class))
                 .build()
                 .put()
                 .contentValues(mock(Iterable.class))
@@ -116,7 +116,7 @@ public class DefaultStorIOSQLiteTest {
     @Test
     public void instantiatePutContentValuesVarArgs() {
         new DefaultStorIOSQLite.Builder()
-                .db(mock(SQLiteDatabase.class))
+                .sqliteOpenHelper(mock(SQLiteOpenHelper.class))
                 .build()
                 .put()
                 .contentValues(mock(ContentValues.class), mock(ContentValues.class))


### PR DESCRIPTION
Closes #318.

This PR makes `StorIOSQLite` : `Closeable`, which allows users close underlying `SQLiteOpenHelper`.

Also, now all work with database goes through `SQLiteOpenHelper` which allows to move initialization to some request where `getWritableDatabase()` or `getReadableDatabase()` call will happen.

@nikitin-da PTAL, this is really major PR for 1.0.0.