### PR TITLE
Fix incorrect usage of Rx startWith()

### DIFF
--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/get/PreparedGetCursor.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/get/PreparedGetCursor.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import com.pushtorefresh.storio.contentresolver.StorIOContentResolver;
 import com.pushtorefresh.storio.contentresolver.query.Query;
 import com.pushtorefresh.storio.operation.internal.MapSomethingToExecuteAsBlocking;
+import com.pushtorefresh.storio.operation.internal.OnSubscribeExecuteAsBlocking;
 
 import rx.Observable;
 import rx.schedulers.Schedulers;
@@ -65,7 +66,7 @@ public final class PreparedGetCursor extends PreparedGet<Cursor, Cursor> {
         return storIOContentResolver
                 .observeChangesOfUri(query.uri()) // each change triggers executeAsBlocking
                 .map(MapSomethingToExecuteAsBlocking.newInstance(this))
-                .startWith(executeAsBlocking())  // start stream with first query result
+                .startWith(Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this))) // start stream with first query result
                 .subscribeOn(Schedulers.io());
     }
 

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/get/PreparedGetListOfObjects.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operation/get/PreparedGetListOfObjects.java
@@ -8,6 +8,7 @@ import com.pushtorefresh.storio.contentresolver.ContentResolverTypeMapping;
 import com.pushtorefresh.storio.contentresolver.StorIOContentResolver;
 import com.pushtorefresh.storio.contentresolver.query.Query;
 import com.pushtorefresh.storio.operation.internal.MapSomethingToExecuteAsBlocking;
+import com.pushtorefresh.storio.operation.internal.OnSubscribeExecuteAsBlocking;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -90,7 +91,7 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<T, List<T>> {
         return storIOContentResolver
                 .observeChangesOfUri(query.uri()) // each change triggers executeAsBlocking
                 .map(MapSomethingToExecuteAsBlocking.newInstance(this))
-                .startWith(executeAsBlocking())   // start stream with first query result
+                .startWith(Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this))) // start stream with first query result
                 .subscribeOn(Schedulers.io());
     }
 

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/get/PreparedGetCursor.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/get/PreparedGetCursor.java
@@ -91,7 +91,7 @@ public final class PreparedGetCursor extends PreparedGet<Cursor> {
             return storIOSQLite
                     .observeChangesInTables(tables) // each change triggers executeAsBlocking
                     .map(MapSomethingToExecuteAsBlocking.newInstance(this))
-                    .startWith(executeAsBlocking()) // start stream with first query result
+                    .startWith(Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this))) // start stream with first query result
                     .subscribeOn(Schedulers.io());
         } else {
             return Observable

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/get/PreparedGetListOfObjects.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operation/get/PreparedGetListOfObjects.java
@@ -110,7 +110,7 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<List<T>> {
             return storIOSQLite
                     .observeChangesInTables(tables) // each change triggers executeAsBlocking
                     .map(MapSomethingToExecuteAsBlocking.newInstance(this))
-                    .startWith(executeAsBlocking()) // start stream with first query result
+                    .startWith(Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this))) // start stream with first query result
                     .subscribeOn(Schedulers.io());
         } else {
             return Observable


### PR DESCRIPTION
Closes #349. Now `startWith()` is async!

@nikitin-da PTAL

