### PR TITLE
Reduce build log level, thnx to Travis 10k limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,13 @@ language: android
 jdk: oraclejdk8
 env:
   matrix:
-    - ANDROID_TARGET=android-22  ANDROID_ABI=armeabi-v7a
+    - ANDROID_TARGET=android-19  ANDROID_ABI=armeabi-v7a
 
 android:
   components:
     - android-22
-    - sys-img-armeabi-v7a-android-22
+    - android-19
+    - sys-img-armeabi-v7a-android-19
     - build-tools-22.0.1
     - extra-android-m2repository
     - extra-android-support

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,12 @@ language: android
 jdk: oraclejdk8
 env:
   matrix:
-    - ANDROID_TARGET=android-18  ANDROID_ABI=armeabi-v7a
+    - ANDROID_TARGET=android-22  ANDROID_ABI=armeabi-v7a
 
 android:
   components:
     - android-22
-    - android-18
-    - sys-img-armeabi-v7a-android-18
+    - sys-img-armeabi-v7a-android-22
     - build-tools-22.0.1
     - extra-android-m2repository
     - extra-android-support

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Please run it from root project directory
-./gradlew clean build checkstyle connectedAndroidTest --info -PdisablePreDex
+./gradlew clean build checkstyle connectedAndroidTest -PdisablePreDex


### PR DESCRIPTION
Travis has limit: 10k logs per build, and we can not see our wanted result in the end:

```
BUILD SUCCESSFUL

Total time: 2 mins 26.981 secs```

So I removed `--info`, but now we can not see tests results…

Uh