### PR TITLE
Fix emission checker behavior in case of unexpected value

### DIFF
--- a/storio-test-common/src/test/java/com/pushtorefresh/storio/test/AbstractEmissionCheckerTest.java
+++ b/storio-test-common/src/test/java/com/pushtorefresh/storio/test/AbstractEmissionCheckerTest.java
@@ -12,6 +12,7 @@ import rx.Observable;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action1;
+import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -94,19 +95,10 @@ public class AbstractEmissionCheckerTest {
             public Subscription subscribe() {
                 return Observable
                         .just("another_value")
-                        .subscribe(new Subscriber<String>() {
+                        .subscribeOn(Schedulers.computation())
+                        .subscribe(new Action1<String>() {
                             @Override
-                            public void onCompleted() {
-                                fail();
-                            }
-
-                            @Override
-                            public void onError(Throwable e) {
-                                // expected
-                            }
-
-                            @Override
-                            public void onNext(String s) {
+                            public void call(String s) {
                                 onNextObtained(s);
                             }
                         });


### PR DESCRIPTION
Before:

If value that was received by emission checker was incorrect -> it'll throw exception which could be handled by Observable's subscriber and it brakes internal checks of emission checker, it may or may not handle it as timeout error.

After:

Now I handle all exceptions manually and threat them as Emission Checker's problem, so Observable won't handle it for us.

And finally, it may help with our flaky tests on CI problem.

+ Bonus -> `build time -= 2 minutes`!