### PR TITLE
Better javadoc formatting, but still not perfect

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_CODE=4
-VERSION_NAME=0.9.4-SNAPSHOT
+VERSION_CODE=5
+VERSION_NAME=0.9.5-SNAPSHOT
 GROUP=com.pushtorefresh.storio
 
 POM_DESCRIPTION=Modern API for SQLiteDatabase and ContentResolver

--- a/gradle/publish-android-lib.gradle
+++ b/gradle/publish-android-lib.gradle
@@ -116,9 +116,16 @@ afterEvaluate { project ->
     }
 
     task androidJavadocs(type: Javadoc) {
-        failOnError false
         source = android.sourceSets.main.java.srcDirs
-        classpath += project.files(android.getBootClasspath()) + project.files(configurations.compileJavadoc)
+
+        classpath += project.files(android.getBootClasspath())
+        classpath += configurations.compileJavadoc
+        classpath += configurations.compile + configurations.provided
+
+        failOnError false // Sorry, but we can not make it work with dependencies between modules
+
+        exclude '**/BuildConfig.java'
+        exclude '**/R.java'
     }
 
     task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {

--- a/storio-common/src/main/java/com/pushtorefresh/storio/internal/ChangesBus.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio/internal/ChangesBus.java
@@ -9,7 +9,7 @@ import static com.pushtorefresh.storio.internal.Environment.RX_JAVA_IS_AVAILABLE
 
 /**
  * FOR INTERNAL USAGE ONLY.
- * <p/>
+ * <p>
  * Thread-safe changes bus.
  */
 public final class ChangesBus<T> {

--- a/storio-common/src/main/java/com/pushtorefresh/storio/internal/Checks.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio/internal/Checks.java
@@ -5,7 +5,7 @@ import android.support.annotation.Nullable;
 
 /**
  * Bunch of check methods
- * <p/>
+ * <p>
  * For internal usage only!
  */
 public final class Checks {

--- a/storio-common/src/main/java/com/pushtorefresh/storio/internal/Queries.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio/internal/Queries.java
@@ -14,7 +14,7 @@ import static java.util.Collections.unmodifiableList;
 
 /**
  * Util methods for queries.
- * <p/>
+ * <p>
  * For internal usage only!
  */
 public final class Queries {

--- a/storio-common/src/main/java/com/pushtorefresh/storio/operations/PreparedOperation.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio/operations/PreparedOperation.java
@@ -14,7 +14,7 @@ public interface PreparedOperation<Result> {
 
     /**
      * Executes operation synchronously in current thread.
-     * <p/>
+     * <p>
      * Notice: Blocking I/O operation should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, execute blocking I/O operation only from background thread.
@@ -28,7 +28,7 @@ public interface PreparedOperation<Result> {
 
     /**
      * Creates {@link rx.Observable} that emits result of Operation.
-     * <p/>
+     * <p>
      * Observable may be "Hot" or "Cold", please read documentation of the concrete implementation.
      *
      * @return observable result of operation with only one {@link rx.Observer#onNext(Object)} call.

--- a/storio-common/src/main/java/com/pushtorefresh/storio/operations/group/GroupOperationResults.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio/operations/group/GroupOperationResults.java
@@ -12,7 +12,7 @@ import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 /**
  * Immutable container for results of {@link PreparedGroupOperation}
  * Thread-safe
- * <p/>
+ * <p>
  * Unfortunately, we can not generify it because each Operation can return different type of result
  */
 public final class GroupOperationResults {

--- a/storio-common/src/main/java/com/pushtorefresh/storio/operations/group/PreparedGroupOperation.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio/operations/group/PreparedGroupOperation.java
@@ -17,9 +17,9 @@ import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJa
 
 /**
  * Prepared Group Operation for StorIO implementations.
- * <p/>
+ * <p>
  * Allows group execution of any combination of {@link PreparedOperation}.
- * <p/>
+ * <p>
  * And yes, you can execute {@link PreparedGroupOperation}
  * as part of {@link PreparedGroupOperation}
  * since it implements {@link PreparedOperation} :).
@@ -35,7 +35,7 @@ public class PreparedGroupOperation implements PreparedOperation<GroupOperationR
 
     /**
      * Executes Group Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -58,10 +58,10 @@ public class PreparedGroupOperation implements PreparedOperation<GroupOperationR
 
     /**
      * Creates {@link Observable} which will perform Group Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * Group Operation only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>

--- a/storio-common/src/main/java/com/pushtorefresh/storio/operations/internal/MapSomethingToExecuteAsBlocking.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio/operations/internal/MapSomethingToExecuteAsBlocking.java
@@ -9,7 +9,7 @@ import rx.functions.Func1;
 /**
  * Required to avoid problems with ClassLoader when RxJava is not in ClassPath
  * We can not use anonymous classes from RxJava directly in StorIO, ClassLoader won't be happy :(
- * <p/>
+ * <p>
  * For internal usage only!
  */
 public final class MapSomethingToExecuteAsBlocking<Something, Result> implements Func1<Something, Result> {

--- a/storio-common/src/main/java/com/pushtorefresh/storio/operations/internal/OnSubscribeExecuteAsBlocking.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio/operations/internal/OnSubscribeExecuteAsBlocking.java
@@ -10,7 +10,7 @@ import rx.Subscriber;
 /**
  * Required to avoid problems with ClassLoader when RxJava is not in ClassPath
  * We can not use anonymous classes from RxJava directly in StorIO, ClassLoader won't be happy :(
- * <p/>
+ * <p>
  * For internal usage only!
  */
 public final class OnSubscribeExecuteAsBlocking<Result> implements Observable.OnSubscribe<Result> {

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/impl/DefaultStorIOContentResolver.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/impl/DefaultStorIOContentResolver.java
@@ -103,7 +103,7 @@ public class DefaultStorIOContentResolver extends StorIOContentResolver {
 
         /**
          * Required: Specifies {@link ContentResolver} for {@link StorIOContentResolver}.
-         * <p/>
+         * <p>
          * You can get in from any {@link android.content.Context}
          * instance: {@code context.getContentResolver().
          * It's safe to use {@link android.app.Activity} as {@link android.content.Context}.
@@ -182,7 +182,7 @@ public class DefaultStorIOContentResolver extends StorIOContentResolver {
 
         /**
          * Gets type mapping for required type.
-         * <p/>
+         * <p>
          * This implementation can handle subclasses of types, that registered its type mapping.
          * For example: You've added type mapping for {@code User.class},
          * and you have {@code UserFromServiceA.class} which extends {@code User.class},

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/delete/DefaultDeleteResolver.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/delete/DefaultDeleteResolver.java
@@ -7,9 +7,9 @@ import com.pushtorefresh.storio.contentresolver.queries.DeleteQuery;
 
 /**
  * Default implementation of {@link DeleteResolver}.
- * <p/>
+ * <p>
  * Simply redirects {@link DeleteQuery} to {@link StorIOContentResolver}.
- * <p/>
+ * <p>
  * Instances of this class are thread-safe.
  */
 public abstract class DefaultDeleteResolver<T> extends DeleteResolver<T> {

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/delete/DeleteResult.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/delete/DeleteResult.java
@@ -10,7 +10,7 @@ import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 
 /**
  * Immutable container for results of Delete Operation.
- * <p/>
+ * <p>
  * Instances of this class are Immutable.
  */
 public final class DeleteResult {

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/delete/DeleteResults.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/delete/DeleteResults.java
@@ -9,7 +9,7 @@ import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 
 /**
  * Immutable container for multiple results of Delete Operation.
- * <p/>
+ * <p>
  * Instances of this class are immutable.
  */
 public final class DeleteResults<T> {

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/delete/PreparedDeleteByQuery.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/delete/PreparedDeleteByQuery.java
@@ -36,7 +36,7 @@ public final class PreparedDeleteByQuery extends PreparedDelete<DeleteResult> {
 
     /**
      * Executes Delete Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -52,10 +52,10 @@ public final class PreparedDeleteByQuery extends PreparedDelete<DeleteResult> {
 
     /**
      * Creates {@link Observable} which will perform Delete Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * delete only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
@@ -112,7 +112,7 @@ public final class PreparedDeleteByQuery extends PreparedDelete<DeleteResult> {
         /**
          * Optional: Specifies resolver for Delete Operation.
          * Allows you to customise behavior of Delete Operation.
-         * <p/>
+         * <p>
          * If no value will be set, builder will use Delete Resolver
          * that simply redirects query to {@link StorIOContentResolver}.
          *

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/delete/PreparedDeleteCollectionOfObjects.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/delete/PreparedDeleteCollectionOfObjects.java
@@ -43,7 +43,7 @@ public final class PreparedDeleteCollectionOfObjects<T> extends PreparedDelete<D
 
     /**
      * Executes Delete Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -104,10 +104,10 @@ public final class PreparedDeleteCollectionOfObjects<T> extends PreparedDelete<D
 
     /**
      * Creates {@link Observable} which will perform Delete Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * delete only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
@@ -156,10 +156,10 @@ public final class PreparedDeleteCollectionOfObjects<T> extends PreparedDelete<D
         /**
          * Optional: Specifies resolver for Delete Operation.
          * Allows you to customise behavior of Delete Operation.
-         * <p/>
+         * <p>
          * Can be set via {@link ContentResolverTypeMapping},
          * If value is not set via {@link ContentResolverTypeMapping}
-         * or explicitly -> exception will be thrown.
+         * or explicitly — exception will be thrown.
          *
          * @param deleteResolver nullable resolver for Delete Operation.
          * @return builder.

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/delete/PreparedDeleteObject.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/delete/PreparedDeleteObject.java
@@ -36,7 +36,7 @@ public final class PreparedDeleteObject<T> extends PreparedDelete<DeleteResult> 
 
     /**
      * Executes Delete Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -70,10 +70,10 @@ public final class PreparedDeleteObject<T> extends PreparedDelete<DeleteResult> 
 
     /**
      * Creates {@link Observable} which will perform Delete Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * delete only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
@@ -124,10 +124,10 @@ public final class PreparedDeleteObject<T> extends PreparedDelete<DeleteResult> 
         /**
          * Optional: Specifies resolver for Delete Operation.
          * Allows you to customise behavior of Delete Operation.
-         * <p/>
+         * <p>
          * Can be set via {@link ContentResolverTypeMapping},
          * If value is not set via {@link ContentResolverTypeMapping}
-         * or explicitly -> exception will be thrown.
+         * or explicitly — exception will be thrown.
          *
          * @param deleteResolver resolver for Delete Operation.
          * @return builder.

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetCursor.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetCursor.java
@@ -39,7 +39,7 @@ public final class PreparedGetCursor extends PreparedGet<Cursor> {
 
     /**
      * Executes Get Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -56,14 +56,14 @@ public final class PreparedGetCursor extends PreparedGet<Cursor> {
     /**
      * Creates "Hot" {@link Observable} which will be subscribed to changes of {@link #query} Uri
      * and will emit result each time change occurs.
-     * <p/>
+     * <p>
      * First result will be emitted immediately after subscription,
      * other emissions will occur only if changes of {@link #query} Uri will occur.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
-     * <p/>
+     * <p>
      * Please don't forget to unsubscribe from this {@link Observable} because
      * it's "Hot" and endless.
      *
@@ -84,7 +84,7 @@ public final class PreparedGetCursor extends PreparedGet<Cursor> {
 
     /**
      * Builder for {@link PreparedGetCursor}.
-     * <p/>
+     * <p>
      * Required: You should specify query see {@link #withQuery(Query)}.
      */
     public static final class Builder {
@@ -138,7 +138,7 @@ public final class PreparedGetCursor extends PreparedGet<Cursor> {
         /**
          * Optional: Specifies {@link GetResolver} for Get Operation
          * which allows you to customize behavior of Get Operation.
-         * <p/>
+         * <p>
          * If no value will be set, builder will use resolver that
          * simply redirects query to {@link StorIOContentResolver}.
          *

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetListOfObjects.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetListOfObjects.java
@@ -52,7 +52,7 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<List<T>> {
 
     /**
      * Executes Prepared Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -104,15 +104,15 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<List<T>> {
     /**
      * Creates "Hot" {@link Observable} which will be subscribed to changes of {@link #query} Uri
      * and will emit result each time change occurs.
-     * <p/>
+     * <p>
      * First result will be emitted immediately after subscription,
      * other emissions will occur only if changes of {@link #query} Uri will occur.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
-     * <p/>
+     * <p>
      * Please don't forget to unsubscribe from this {@link Observable}
      * because it's "Hot" and endless.
      *
@@ -190,9 +190,9 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<List<T>> {
         /**
          * Optional: Specifies {@link GetResolver} for Get Operation
          * which allows you to customize behavior of Get Operation.
-         * <p/>
+         * <p>
          * Can be set via {@link ContentResolverTypeMapping},
-         * If value is not set via {@link ContentResolverTypeMapping} -> exception will be thrown.
+         * If value is not set via {@link ContentResolverTypeMapping} — exception will be thrown.
          *
          * @param getResolver GetResolver.
          * @return builder.

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/PreparedPutCollectionOfObjects.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/PreparedPutCollectionOfObjects.java
@@ -43,7 +43,7 @@ public final class PreparedPutCollectionOfObjects<T> extends PreparedPut<PutResu
 
     /**
      * Executes Put Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -104,10 +104,10 @@ public final class PreparedPutCollectionOfObjects<T> extends PreparedPut<PutResu
 
     /**
      * Creates {@link Observable} which will perform Put Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * put only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
@@ -151,10 +151,10 @@ public final class PreparedPutCollectionOfObjects<T> extends PreparedPut<PutResu
          * Optional: Specifies resolver for Put Operation
          * that should define behavior of Put Operation: insert or update
          * of the objects.
-         * <p/>
+         * <p>
          * Can be set via {@link ContentResolverTypeMapping},
          * If value is not set via {@link ContentResolverTypeMapping}
-         * or explicitly -> exception will be thrown.
+         * or explicitly — exception will be thrown.
          *
          * @param putResolver nullable resolver for Put Operation.
          * @return builder.

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/PreparedPutContentValues.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/PreparedPutContentValues.java
@@ -34,7 +34,7 @@ public final class PreparedPutContentValues extends PreparedPut<PutResult> {
 
     /**
      * Executes Put Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -50,10 +50,10 @@ public final class PreparedPutContentValues extends PreparedPut<PutResult> {
 
     /**
      * Creates {@link Observable} which will perform Put Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * put only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
@@ -74,7 +74,7 @@ public final class PreparedPutContentValues extends PreparedPut<PutResult> {
 
     /**
      * Builder for {@link PreparedPutContentValues}.
-     * <p/>
+     * <p>
      * Required: You should specify put resolver see {@link #withPutResolver(PutResolver)}.
      */
     public static final class Builder {

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/PreparedPutContentValuesIterable.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/PreparedPutContentValuesIterable.java
@@ -38,7 +38,7 @@ public final class PreparedPutContentValuesIterable extends PreparedPut<PutResul
 
     /**
      * Executes Put Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -61,10 +61,10 @@ public final class PreparedPutContentValuesIterable extends PreparedPut<PutResul
 
     /**
      * Creates {@link Observable} which will perform Put Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * put only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
@@ -85,7 +85,7 @@ public final class PreparedPutContentValuesIterable extends PreparedPut<PutResul
 
     /**
      * Builder for {@link PreparedPutContentValuesIterable}.
-     * <p/>
+     * <p>
      * Required: You should specify query see {@link #withPutResolver(PutResolver)}.
      */
     public static final class Builder {

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/PreparedPutObject.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/PreparedPutObject.java
@@ -37,7 +37,7 @@ public final class PreparedPutObject<T> extends PreparedPut<PutResult> {
 
     /**
      * Executes Put Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -71,10 +71,10 @@ public final class PreparedPutObject<T> extends PreparedPut<PutResult> {
 
     /**
      * Creates {@link Observable} which will perform Put Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * put only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
@@ -117,10 +117,10 @@ public final class PreparedPutObject<T> extends PreparedPut<PutResult> {
          * Optional: Specifies resolver for Put Operation
          * that should define behavior of Put Operation: insert or update
          * of the object.
-         * <p/>
+         * <p>
          * Can be set via {@link ContentResolverTypeMapping},
          * If value is not set via {@link ContentResolverTypeMapping}
-         * or explicitly -> exception will be thrown.
+         * or explicitly — exception will be thrown.
          *
          * @param putResolver nullable resolver for Put Operation.
          * @return builder.

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/InsertQuery.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/InsertQuery.java
@@ -7,7 +7,7 @@ import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 
 /**
  * Insert query for {@link com.pushtorefresh.storio.contentresolver.StorIOContentResolver}.
- * <p/>
+ * <p>
  * Instances of this class are Immutable.
  */
 public final class InsertQuery {
@@ -67,7 +67,7 @@ public final class InsertQuery {
 
     /**
      * Builder for {@link InsertQuery}.
-     * <p/>
+     * <p>
      * Yep, it looks stupid with only one parameter — Uri, but think about future,
      * we can add other things later without breaking the API!
      */

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/Query.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/Query.java
@@ -64,7 +64,7 @@ public class Query {
     /**
      * Gets optional immutable list of columns that should be received.
      * <p>
-     * If list is empty -> all columns will be received.
+     * If list is empty — all columns will be received.
      *
      * @return non-null, immutable list of columns that should be received.
      */

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/UpdateQuery.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/UpdateQuery.java
@@ -13,7 +13,7 @@ import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullListO
 
 /**
  * Update query for {@link com.pushtorefresh.storio.contentresolver.StorIOContentResolver}.
- * <p/>
+ * <p>
  * Instances of this class are Immutable.
  */
 public final class UpdateQuery {
@@ -39,7 +39,7 @@ public final class UpdateQuery {
 
     /**
      * Gets {@code content://} URI of the insertion request.
-     * <p/>
+     * <p>
      * This can potentially have a record ID if this is an update request for a specific record.
      *
      * @return non-null URI of the update request.
@@ -51,11 +51,11 @@ public final class UpdateQuery {
 
     /**
      * Gets {@code WHERE} clause.
-     * <p/>
+     * <p>
      * Optional filter declaring which rows to update.
-     * <p/>
+     * <p>
      * Formatted as an SQL {@code WHERE} clause (excluding the {@code WHERE} itself).
-     * <p/>
+     * <p>
      * If empty — Query will update all rows for specified URI.
      *
      * @return non-null {@code WHERE} clause.
@@ -165,7 +165,7 @@ public final class UpdateQuery {
 
         /**
          * Optional: Specifies where clause.
-         * <p/>
+         * <p>
          * Default value is {@code null}.
          *
          * @param where an optional filter to match rows to update.
@@ -180,10 +180,10 @@ public final class UpdateQuery {
 
         /**
          * Optional: Specifies arguments for where clause.
-         * <p/>
+         * <p>
          * Passed objects will be immediately converted to
          * list {@link String} via calling {@link Object#toString()}.
-         * <p/>
+         * <p>
          * Default value is {@code null}.
          *
          * @param whereArgs arguments for {@link UpdateQuery#where}.

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/StorIOSQLite.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/StorIOSQLite.java
@@ -24,7 +24,7 @@ import rx.Observable;
 
 /**
  * Powerful but simple abstraction for {@link android.database.sqlite.SQLiteDatabase}.
- * <p/>
+ * <p>
  * It's an abstract class instead of interface because we want to have ability to add some
  * changes without breaking existing implementations.
  */
@@ -111,7 +111,7 @@ public abstract class StorIOSQLite implements Closeable {
 
         /**
          * Gets {@link SQLiteTypeMapping} for required type.
-         * <p/>
+         * <p>
          * Result can be {@code null}.
          *
          * @param type type.
@@ -197,7 +197,7 @@ public abstract class StorIOSQLite implements Closeable {
 
         /**
          * Begins a transaction in EXCLUSIVE mode.
-         * <p/>
+         * <p>
          * Thread will be blocked on call to this method if another thread already in transaction,
          * as soon as first thread will end its transaction this thread will be unblocked.
          * <p>
@@ -208,7 +208,7 @@ public abstract class StorIOSQLite implements Closeable {
          * marked as clean (by calling setTransactionSuccessful). Otherwise they will be committed.
          * </p>
          * <p>Here is the standard idiom for transactions:
-         * <p/>
+         * <p>
          * <pre>
          *   db.beginTransaction();
          *   try {

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/impl/DefaultStorIOSQLite.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/impl/DefaultStorIOSQLite.java
@@ -33,7 +33,7 @@ import static java.util.Collections.unmodifiableMap;
 
 /**
  * Default implementation of {@link StorIOSQLite} for {@link android.database.sqlite.SQLiteDatabase}.
- * <p/>
+ * <p>
  * Thread-safe.
  */
 public class DefaultStorIOSQLite extends StorIOSQLite {
@@ -82,7 +82,7 @@ public class DefaultStorIOSQLite extends StorIOSQLite {
 
     /**
      * Closes underlying {@link SQLiteOpenHelper}.
-     * <p/>
+     * <p>
      * All calls to this instance of {@link StorIOSQLite}
      * after call to this method can produce exceptions
      * and undefined behavior.
@@ -115,7 +115,7 @@ public class DefaultStorIOSQLite extends StorIOSQLite {
 
         /**
          * Required: Specifies SQLite Open helper for internal usage.
-         * <p/>
+         * <p>
          *
          * @param sqliteOpenHelper a SQLiteOpenHelper for internal usage.
          * @return builder.
@@ -209,7 +209,7 @@ public class DefaultStorIOSQLite extends StorIOSQLite {
 
         /**
          * Gets type mapping for required type.
-         * <p/>
+         * <p>
          * This implementation can handle subclasses of types, that registered its type mapping.
          * For example: You've added type mapping for {@code User.class},
          * and you have {@code UserFromServiceA.class} which extends {@code User.class},

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/delete/DeleteResults.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/delete/DeleteResults.java
@@ -9,7 +9,7 @@ import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 
 /**
  * Immutable container for results of Delete Operation
- * <p/>
+ * <p>
  * Instances of this class are Immutable
  *
  * @param <T> type of objects

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/delete/PreparedDeleteByQuery.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/delete/PreparedDeleteByQuery.java
@@ -33,7 +33,7 @@ public final class PreparedDeleteByQuery extends PreparedDelete<DeleteResult> {
 
     /**
      * Executes Delete Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -51,10 +51,10 @@ public final class PreparedDeleteByQuery extends PreparedDelete<DeleteResult> {
 
     /**
      * Creates {@link Observable} which will perform Delete Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * delete only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
@@ -101,7 +101,7 @@ public final class PreparedDeleteByQuery extends PreparedDelete<DeleteResult> {
 
         /**
          * Optional: Specifies Delete Resolver for Delete Operation.
-         * <p/>
+         * <p>
          * If no value was specified, builder will use resolver that
          * simply redirects query to {@link StorIOSQLite}.
          *

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/delete/PreparedDeleteCollectionOfObjects.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/delete/PreparedDeleteCollectionOfObjects.java
@@ -50,7 +50,7 @@ public final class PreparedDeleteCollectionOfObjects<T> extends PreparedDelete<D
 
     /**
      * Executes Delete Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -151,10 +151,10 @@ public final class PreparedDeleteCollectionOfObjects<T> extends PreparedDelete<D
 
     /**
      * Creates {@link Observable} which will perform Delete Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * delete only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
@@ -197,7 +197,7 @@ public final class PreparedDeleteCollectionOfObjects<T> extends PreparedDelete<D
 
         /**
          * Optional: Defines that Delete Operation will use transaction or not.
-         * <p/>
+         * <p>
          * By default, transaction will be used.
          *
          * @param useTransaction {@code true} to use transaction, {@code false} to not.
@@ -211,11 +211,11 @@ public final class PreparedDeleteCollectionOfObjects<T> extends PreparedDelete<D
 
         /**
          * Optional: Specifies {@link DeleteResolver} for Delete Operation.
-         * <p/>
-         * <p/>
+         * <p>
+         * <p>
          * Can be set via {@link SQLiteTypeMapping},
          * If value is not set via {@link SQLiteTypeMapping}
-         * or explicitly -> exception will be thrown.
+         * or explicitly — exception will be thrown.
          *
          * @param deleteResolver {@link DeleteResolver} for Delete Operation.
          * @return builder.

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/delete/PreparedDeleteObject.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/delete/PreparedDeleteObject.java
@@ -37,7 +37,7 @@ public final class PreparedDeleteObject<T> extends PreparedDelete<DeleteResult> 
 
     /**
      * Executes Delete Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -75,10 +75,10 @@ public final class PreparedDeleteObject<T> extends PreparedDelete<DeleteResult> 
 
     /**
      * Creates {@link Observable} which will perform Delete Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * delete only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
@@ -119,10 +119,10 @@ public final class PreparedDeleteObject<T> extends PreparedDelete<DeleteResult> 
 
         /**
          * Optional: Specifies {@link DeleteResolver} for Delete Operation.
-         * <p/>
+         * <p>
          * Can be set via {@link SQLiteTypeMapping},
          * If resolver is not set via {@link SQLiteTypeMapping}
-         * or explicitly -> exception will be thrown.
+         * or explicitly — exception will be thrown.
          *
          * @param deleteResolver delete resolver.
          * @return builder.

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/execute/PreparedExecuteSQL.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/execute/PreparedExecuteSQL.java
@@ -35,7 +35,7 @@ public final class PreparedExecuteSQL implements PreparedOperation<Object> {
 
     /**
      * Executes SQL Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -62,10 +62,10 @@ public final class PreparedExecuteSQL implements PreparedOperation<Object> {
     /**
      * Creates {@link Observable} which will perform Execute SQL Operation
      * and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * execution of SQL only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/get/PreparedGetCursor.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/get/PreparedGetCursor.java
@@ -44,7 +44,7 @@ public final class PreparedGetCursor extends PreparedGet<Cursor> {
 
     /**
      * Executes Get Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -66,7 +66,7 @@ public final class PreparedGetCursor extends PreparedGet<Cursor> {
     /**
      * Creates "Hot" {@link Observable} which will be subscribed to changes of tables from query
      * and will emit result each time change occurs.
-     * <p/>
+     * <p>
      * First result will be emitted immediately after subscription,
      * other emissions will occur only if changes of tables from query will occur during lifetime of
      * the {@link Observable}.
@@ -74,7 +74,7 @@ public final class PreparedGetCursor extends PreparedGet<Cursor> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
-     * <p/>
+     * <p>
      * Please don't forget to unsubscribe from this {@link Observable} because
      * it's "Hot" and endless.
      *
@@ -112,7 +112,7 @@ public final class PreparedGetCursor extends PreparedGet<Cursor> {
 
     /**
      * Builder for {@link PreparedGetCursor}.
-     * <p/>
+     * <p>
      * Required: You should specify query by call
      * {@link #withQuery(Query)} or {@link #withQuery(RawQuery)}.
      */

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/get/PreparedGetListOfObjects.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/get/PreparedGetListOfObjects.java
@@ -58,7 +58,7 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<List<T>> {
 
     /**
      * Executes Get Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -119,7 +119,7 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<List<T>> {
     /**
      * Creates "Hot" {@link Observable} which will be subscribed to changes of tables from query
      * and will emit result each time change occurs.
-     * <p/>
+     * <p>
      * First result will be emitted immediately after subscription,
      * other emissions will occur only if changes of tables from query will occur during lifetime of
      * the {@link Observable}.
@@ -127,7 +127,7 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<List<T>> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
      * </dl>
-     * <p/>
+     * <p>
      * Please don't forget to unsubscribe from this {@link Observable} because
      * it's "Hot" and endless.
      *
@@ -249,10 +249,10 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<List<T>> {
         /**
          * Optional: Specifies resolver for Get Operation which can be used
          * to provide custom behavior of Get Operation.
-         * <p/>
+         * <p>
          * {@link SQLiteTypeMapping} can be used to set default GetResolver.
          * If GetResolver is not set via {@link SQLiteTypeMapping}
-         * or explicitly -> exception will be thrown.
+         * or explicitly — exception will be thrown.
          *
          * @param getResolver nullable resolver for Get Operation.
          * @return builder.

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/put/PreparedPutCollectionOfObjects.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/put/PreparedPutCollectionOfObjects.java
@@ -45,7 +45,7 @@ public final class PreparedPutCollectionOfObjects<T> extends PreparedPut<PutResu
 
     /**
      * Executes Put Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -144,10 +144,10 @@ public final class PreparedPutCollectionOfObjects<T> extends PreparedPut<PutResu
 
     /**
      * Creates {@link Observable} which will perform Put Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * put only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
@@ -191,9 +191,9 @@ public final class PreparedPutCollectionOfObjects<T> extends PreparedPut<PutResu
         /**
          * Optional: Specifies {@link PutResolver} for Put Operation
          * which allows you to customize behavior of Put Operation
-         * <p/>
+         * <p>
          * Can be set via {@link SQLiteTypeMapping}
-         * If it's not set via {@link SQLiteTypeMapping} or explicitly -> exception will be thrown
+         * If it's not set via {@link SQLiteTypeMapping} or explicitly — exception will be thrown
          *
          * @param putResolver put resolver
          * @return builder
@@ -207,7 +207,7 @@ public final class PreparedPutCollectionOfObjects<T> extends PreparedPut<PutResu
 
         /**
          * Optional: Defines that Put Operation will use transaction if it is supported by implementation of {@link StorIOSQLite}
-         * <p/>
+         * <p>
          * By default, transaction will be used
          *
          * @return builder

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/put/PreparedPutContentValues.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/put/PreparedPutContentValues.java
@@ -33,7 +33,7 @@ public final class PreparedPutContentValues extends PreparedPut<PutResult> {
 
     /**
      * Executes Put Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -51,10 +51,10 @@ public final class PreparedPutContentValues extends PreparedPut<PutResult> {
 
     /**
      * Creates {@link Observable} which will perform Put Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * put only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/put/PreparedPutContentValuesIterable.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/put/PreparedPutContentValuesIterable.java
@@ -43,7 +43,7 @@ public final class PreparedPutContentValuesIterable extends PreparedPut<PutResul
 
     /**
      * Executes Put Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -99,10 +99,10 @@ public final class PreparedPutContentValuesIterable extends PreparedPut<PutResul
 
     /**
      * Creates {@link Observable} which will perform Put Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * put only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
@@ -182,7 +182,7 @@ public final class PreparedPutContentValuesIterable extends PreparedPut<PutResul
         /**
          * Optional: Defines that Put Operation will use transaction
          * if it is supported by implementation of {@link StorIOSQLite}
-         * <p/>
+         * <p>
          * By default, transaction will be used
          *
          * @return builder

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/put/PreparedPutObject.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/put/PreparedPutObject.java
@@ -37,7 +37,7 @@ public final class PreparedPutObject<T> extends PreparedPut<PutResult> {
 
     /**
      * Executes Put Operation immediately in current thread.
-     * <p/>
+     * <p>
      * Notice: This is blocking I/O operation that should not be executed on the Main Thread,
      * it can cause ANR (Activity Not Responding dialog), block the UI and drop animations frames.
      * So please, call this method on some background thread. See {@link WorkerThread}.
@@ -74,10 +74,10 @@ public final class PreparedPutObject<T> extends PreparedPut<PutResult> {
 
     /**
      * Creates {@link Observable} which will perform Put Operation and send result to observer.
-     * <p/>
+     * <p>
      * Returned {@link Observable} will be "Cold Observable", which means that it performs
      * put only after subscribing to it. Also, it emits the result once.
-     * <p/>
+     * <p>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>Operates on {@link Schedulers#io()}.</dd>
@@ -119,9 +119,9 @@ public final class PreparedPutObject<T> extends PreparedPut<PutResult> {
         /**
          * Optional: Specifies {@link PutResolver} for Put Operation
          * which allows you to customize behavior of Put Operation.
-         * <p/>
+         * <p>
          * Can be set via {@link SQLiteTypeMapping}
-         * If it's not set via {@link SQLiteTypeMapping} or explicitly -> exception will be thrown.
+         * If it's not set via {@link SQLiteTypeMapping} or explicitly — exception will be thrown.
          *
          * @param putResolver put resolver.
          * @return builder.

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/InsertQuery.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/InsertQuery.java
@@ -7,7 +7,7 @@ import static com.pushtorefresh.storio.internal.Checks.checkNotEmpty;
 
 /**
  * Insert query for {@link com.pushtorefresh.storio.sqlite.StorIOSQLite}.
- * <p/>
+ * <p>
  * Instances of this class are immutable.
  */
 public final class InsertQuery {
@@ -40,7 +40,7 @@ public final class InsertQuery {
     /**
      * Gets tricky-wiki hack for {@code null} columns in
      * {@link android.database.sqlite.SQLiteDatabase}.
-     * <p/>
+     * <p>
      * SQL doesn't allow inserting a completely empty row
      * without naming at least one column name. If your provided values
      * are empty, no column names are known and an empty row can't be
@@ -135,12 +135,12 @@ public final class InsertQuery {
 
         /**
          * Optional: Specifies {@code NULL} column hack.
-         * <p/>
+         * <p>
          * SQL doesn't allow inserting a completely empty row without naming at least one column name.
          * If your provided values are empty, no column names are known and an empty row can't be inserted.
          * If not set to null, the nullColumnHack parameter provides the name of nullable column name
          * to explicitly insert a NULL into in the case where your values is empty.
-         * <p/>
+         * <p>
          * Default value is {@code null}.
          *
          * @param nullColumnHack optional null column hack.

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/Query.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/Query.java
@@ -85,7 +85,7 @@ public class Query {
     /**
      * Gets optional immutable list of columns that should be received.
      * <p>
-     * If list is empty -> all columns will be received.
+     * If list is empty — all columns will be received.
      *
      * @return non-null, immutable list of columns that should be received.
      */
@@ -316,7 +316,7 @@ public class Query {
         /**
          * Optional: Specifies list of columns that should be received.
          * <p>
-         * If list will be {@code null} or empty -> all columns will be received.
+         * If list will be {@code null} or empty — all columns will be received.
          * <p>
          * Default value is {@code null}.
          *

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/RawQuery.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/RawQuery.java
@@ -14,7 +14,7 @@ import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullSet;
 
 /**
  * Raw SQL query for {@link com.pushtorefresh.storio.sqlite.StorIOSQLite}.
- * <p/>
+ * <p>
  * Instances of this class are immutable.
  */
 public class RawQuery {
@@ -65,7 +65,7 @@ public class RawQuery {
 
     /**
      * Gets optional immutable set of tables which will be affected by this query.
-     * <p/>
+     * <p>
      * They will be used to notify observers of that tables.
      *
      * @return non-null, immutable set of tables, affected by this query.
@@ -77,7 +77,7 @@ public class RawQuery {
 
     /**
      * Gets optional immutable set of tables that should be observed by this query.
-     * <p/>
+     * <p>
      * They will be used to observe changes of that tables and re-execute this query.
      *
      * @return non-null, immutable set of tables, that should be observed by this query.
@@ -175,10 +175,10 @@ public class RawQuery {
         /**
          * Optional: Specifies arguments for SQL query,
          * please use arguments to avoid SQL injections.
-         * <p/>
+         * <p>
          * Passed objects will be immediately converted
          * to list of {@link String} via calling {@link Object#toString()}.
-         * <p/>
+         * <p>
          * Default value is {@code null}.
          *
          * @param args arguments fro SQL query.
@@ -194,7 +194,7 @@ public class RawQuery {
         /**
          * Optional: Specifies set of tables which will be affected by this query.
          * They will be used to notify observers of that tables.
-         * <p/>
+         * <p>
          * Default value is {@code null}.
          *
          * @param tables set of tables which will be affected by this query.
@@ -214,7 +214,7 @@ public class RawQuery {
         /**
          * Optional: Specifies set of tables that should be observed by this query.
          * They will be used to re-execute query if one of the tables will be changed.
-         * <p/>
+         * <p>
          * Default values is {@code null}.
          *
          * @param tables set of tables that should be observed by this query.

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/UpdateQuery.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/UpdateQuery.java
@@ -11,7 +11,7 @@ import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullListO
 
 /**
  * Update query for {@link com.pushtorefresh.storio.sqlite.StorIOSQLite}.
- * <p/>
+ * <p>
  * Instances of this class are immutable.
  */
 public final class UpdateQuery {
@@ -47,11 +47,11 @@ public final class UpdateQuery {
 
     /**
      * Gets {@code WHERE} clause.
-     * <p/>
+     * <p>
      * Optional filter declaring which rows to update.
-     * <p/>
+     * <p>
      * Formatted as an SQL {@code WHERE} clause (excluding the {@code WHERE} itself).
-     * <p/>
+     * <p>
      * If empty — Query will update all rows for the given table.
      *
      * @return non-null {@code WHERE} clause.
@@ -153,13 +153,13 @@ public final class UpdateQuery {
 
         /**
          * Optional: Specifies {@code WHERE} clause.
-         * <p/>
+         * <p>
          * Optional filter declaring which rows to return.
-         * <p/>
+         * <p>
          * Formatted as an SQL WHERE clause (excluding the {@code WHERE} itself).
-         * <p/>
+         * <p>
          * Passing {@code null} will UPDATE all rows for the given table.
-         * <p/>
+         * <p>
          * Default value is {@code null}.
          *
          * @param where {@code WHERE} clause.
@@ -174,10 +174,10 @@ public final class UpdateQuery {
 
         /**
          * Optional: Specifies arguments for {@code WHERE} clause.
-         * <p/>
+         * <p>
          * Passed objects will be immediately converted
          * to list of {@link String} via calling {@link Object#toString()}.
-         * <p/>
+         * <p>
          * Default value is {@code null}.
          *
          * @param whereArgs list of arguments for {@code WHERE} clause.

--- a/storio-test-common/src/main/java/com/pushtorefresh/storio/test/ObservableBehaviorChecker.java
+++ b/storio-test-common/src/main/java/com/pushtorefresh/storio/test/ObservableBehaviorChecker.java
@@ -18,7 +18,7 @@ public class ObservableBehaviorChecker<T> {
 
     /**
      * Required: Specifies {@link Observable} for the check
-     * <p/>
+     * <p>
      * Default value is <code>null</code>
      *
      * @param observable observable
@@ -32,9 +32,9 @@ public class ObservableBehaviorChecker<T> {
 
     /**
      * Required: Specifies expected number of emissions of the {@link Observable}
-     * <p/>
+     * <p>
      * If {@link Observable} will emit more or less items, check will fail
-     * <p/>
+     * <p>
      * Default value is <code>null</code>
      *
      * @param expectedNumberOfEmission expected number of emissions
@@ -48,9 +48,9 @@ public class ObservableBehaviorChecker<T> {
 
     /**
      * Required: Specifies test action which will be applied to each emission of the {@link Observable}
-     * <p/>
+     * <p>
      * Action may throw an exception if emissions is not expected, etc
-     * <p/>
+     * <p>
      * Default value is <code>null</code>
      *
      * @param testAction test action which will be applied to each emission of the {@link Observable}


### PR DESCRIPTION
Uh, spent two hours on fighting with Gradle + Android Gradle Plugin + Javadoc generating, almost everything is done except cross-module dependencies: for example, for `storio-sqlite` and `storio-content-resolver` javadoc tool does not see classes from `storio-common`…

Anyway, this is better than nothing.

@nikitin-da PTAL and what about release tomorrow (Tuesday)?