### PR TITLE
Use the Cache for ~/.m2 and ~/.gradle, Luke

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,8 @@ script:
 
 notifications:
   email: false
+  
+cache:
+  directories:
+    - $HOME/.m2
+    - $HOME/.gradle


### PR DESCRIPTION
It should make builds on Travis CI faster

@nikitin-da PTAL