### PR TITLE
Fix race condition in integration tests for StorIOContentResolver

### DIFF
--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/ObserveChangesTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/ObserveChangesTest.java
@@ -72,7 +72,7 @@ public class ObserveChangesTest extends IntegrationTest {
 
             assertTrue(putResult.wasInserted());
 
-            emissionChecker.assertThatNextExpectedValueReceived();
+            emissionChecker.awaitNextExpectedValue();
         }
 
         emissionChecker.assertThatNoExpectedValuesLeft();
@@ -82,7 +82,7 @@ public class ObserveChangesTest extends IntegrationTest {
     @Test
     public void shouldReceiveChangeAfterEachUpdate() {
         // First of all -> insert some tweets into the Content Provider
-        final List<Tweet> tweets = putTweets(TestFactory.newTweets(10));
+        final List<Tweet> tweets = insertTweets(TestFactory.newTweets(10));
 
         final Queue<Changes> expectedChanges = new LinkedList<Changes>();
 
@@ -103,7 +103,7 @@ public class ObserveChangesTest extends IntegrationTest {
 
             assertTrue(putResult.wasUpdated());
 
-            emissionChecker.assertThatNextExpectedValueReceived();
+            emissionChecker.awaitNextExpectedValue();
         }
 
         emissionChecker.assertThatNoExpectedValuesLeft();
@@ -113,7 +113,7 @@ public class ObserveChangesTest extends IntegrationTest {
     @Test
     public void shouldReceiveChangeAfterEachDelete() {
         // First of all -> insert some tweets into the Content Provider
-        final List<Tweet> tweets = putTweets(TestFactory.newTweets(10));
+        final List<Tweet> tweets = insertTweets(TestFactory.newTweets(10));
 
         final Queue<Changes> expectedChanges = new LinkedList<Changes>();
 
@@ -134,7 +134,7 @@ public class ObserveChangesTest extends IntegrationTest {
 
             assertEquals(1, deleteResult.numberOfRowsDeleted());
 
-            emissionChecker.assertThatNextExpectedValueReceived();
+            emissionChecker.awaitNextExpectedValue();
         }
 
         emissionChecker.assertThatNoExpectedValuesLeft();

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/RxQueryTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/RxQueryTest.java
@@ -57,7 +57,7 @@ public class RxQueryTest extends IntegrationTest {
     @Test
     public void queryShouldBeUpdatedAfterInsert() {
         // First of all -> insert some tweets into the Content Provider
-        final List<Tweet> tweets = putTweets(TestFactory.newTweets(10));
+        final List<Tweet> tweets = insertTweets(TestFactory.newTweets(10));
 
         final Queue<List<Tweet>> expectedTweets = new LinkedList<List<Tweet>>();
 
@@ -76,7 +76,7 @@ public class RxQueryTest extends IntegrationTest {
         final Subscription subscription = emissionChecker.subscribe();
 
         // We should receive 10 tweets after subscription
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         final PutResult putResult = storIOContentResolver
                 .put()
@@ -87,7 +87,7 @@ public class RxQueryTest extends IntegrationTest {
         assertTrue(putResult.wasInserted());
 
         // Then we should receive 11 tweets
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         emissionChecker.assertThatNoExpectedValuesLeft();
         subscription.unsubscribe();
@@ -96,7 +96,7 @@ public class RxQueryTest extends IntegrationTest {
     @Test
     public void queryShouldBeUpdatedAfterUpdate() {
         // First of all -> insert some tweets into the Content Provider
-        final List<Tweet> tweets = putTweets(TestFactory.newTweets(10));
+        final List<Tweet> tweets = insertTweets(TestFactory.newTweets(10));
 
         final Queue<List<Tweet>> expectedTweets = new LinkedList<List<Tweet>>();
 
@@ -115,7 +115,7 @@ public class RxQueryTest extends IntegrationTest {
         final Subscription subscription = emissionChecker.subscribe();
 
         // We should receive 10 tweets after subscription
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         final PutResult putResult = storIOContentResolver
                 .put()
@@ -126,7 +126,7 @@ public class RxQueryTest extends IntegrationTest {
         assertTrue(putResult.wasUpdated());
 
         // Then we should receive 10 tweets after update, but first tweet should be changed
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         emissionChecker.assertThatNoExpectedValuesLeft();
         subscription.unsubscribe();
@@ -135,7 +135,7 @@ public class RxQueryTest extends IntegrationTest {
     @Test
     public void queryShouldBeUpdatedAfterDelete() {
         // First of all -> insert some tweets into the Content Provider
-        final List<Tweet> tweets = putTweets(TestFactory.newTweets(10));
+        final List<Tweet> tweets = insertTweets(TestFactory.newTweets(10));
 
         final Queue<List<Tweet>> expectedTweets = new LinkedList<List<Tweet>>();
 
@@ -152,7 +152,7 @@ public class RxQueryTest extends IntegrationTest {
         final Subscription subscription = emissionChecker.subscribe();
 
         // We should receive 10 tweets after subscription
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         final DeleteResult deleteResult = storIOContentResolver
                 .delete()
@@ -163,7 +163,7 @@ public class RxQueryTest extends IntegrationTest {
         assertEquals(1, deleteResult.numberOfRowsDeleted());
 
         // Then we should receive 9 tweets after delete, first tweet should be deleted
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         emissionChecker.assertThatNoExpectedValuesLeft();
         subscription.unsubscribe();

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/integration/ObserveChangesTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/integration/ObserveChangesTest.java
@@ -56,7 +56,7 @@ public class ObserveChangesTest extends BaseTest {
         putUsersBlocking(users);
 
         // Should receive changes of Users table
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         emissionChecker.assertThatNoExpectedValuesLeft();
 
@@ -85,7 +85,7 @@ public class ObserveChangesTest extends BaseTest {
                 .executeAsBlocking();
 
         // Should receive changes of Users table
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         emissionChecker.assertThatNoExpectedValuesLeft();
 
@@ -105,7 +105,7 @@ public class ObserveChangesTest extends BaseTest {
         deleteUsersBlocking(users);
 
         // Should receive changes of Users table
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         emissionChecker.assertThatNoExpectedValuesLeft();
 

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/integration/RxQueryTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/integration/RxQueryTest.java
@@ -63,12 +63,12 @@ public class RxQueryTest extends BaseTest {
         final Subscription subscription = emissionChecker.subscribe();
 
         // Should receive initial users
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         putUsersBlocking(usersForInsert);
 
         // Should receive initial users + inserted users
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         emissionChecker.assertThatNoExpectedValuesLeft();
 
@@ -93,7 +93,7 @@ public class RxQueryTest extends BaseTest {
         final Subscription subscription = emissionChecker.subscribe();
 
         // Should receive all users
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         storIOSQLite
                 .put()
@@ -102,7 +102,7 @@ public class RxQueryTest extends BaseTest {
                 .executeAsBlocking();
 
         // Should receive updated users
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         emissionChecker.assertThatNoExpectedValuesLeft();
 
@@ -129,12 +129,12 @@ public class RxQueryTest extends BaseTest {
         final Subscription subscription = emissionChecker.subscribe();
 
         // Should receive all users
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         deleteUsersBlocking(usersThatShouldBeDeleted);
 
         // Should receive users that should be saved
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         emissionChecker.assertThatNoExpectedValuesLeft();
 

--- a/storio-test-common/src/main/java/com/pushtorefresh/storio/test/AbstractEmissionChecker.java
+++ b/storio-test-common/src/main/java/com/pushtorefresh/storio/test/AbstractEmissionChecker.java
@@ -25,7 +25,7 @@ public abstract class AbstractEmissionChecker<T> {
     }
 
     /**
-     * Returns timeout of assertion for {@link #assertThatNextExpectedValueReceived()}.
+     * Returns timeout of assertion for {@link #awaitNextExpectedValue()}.
      *
      * @return timeout in millis.
      */
@@ -36,7 +36,7 @@ public abstract class AbstractEmissionChecker<T> {
     /**
      * Asserts that next expected value was received.
      */
-    public void assertThatNextExpectedValueReceived() {
+    public void awaitNextExpectedValue() {
         final long startTime = System.currentTimeMillis(); // We can not use SystemClock here :( Not in class path
         final long timeoutMillis = timeoutMillis();
 
@@ -97,7 +97,6 @@ public abstract class AbstractEmissionChecker<T> {
         }
     }
 
-    // TODO: Refactor, probably better to provide Observable itself.
     @NonNull
     public abstract Subscription subscribe();
 }

--- a/storio-test-common/src/test/java/com/pushtorefresh/storio/test/AbstractEmissionCheckerTest.java
+++ b/storio-test-common/src/test/java/com/pushtorefresh/storio/test/AbstractEmissionCheckerTest.java
@@ -79,7 +79,7 @@ public class AbstractEmissionCheckerTest {
         Subscription subscription = emissionChecker.subscribe();
 
         // Should not throw exception
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         subscription.unsubscribe();
     }
@@ -108,7 +108,7 @@ public class AbstractEmissionCheckerTest {
         Subscription subscription = emissionChecker.subscribe();
 
         try {
-            emissionChecker.assertThatNextExpectedValueReceived();
+            emissionChecker.awaitNextExpectedValue();
             fail();
         } catch (AssertionError expected) {
             // it's okay
@@ -146,7 +146,7 @@ public class AbstractEmissionCheckerTest {
         Subscription subscription = emissionChecker.subscribe();
 
         try {
-            emissionChecker.assertThatNextExpectedValueReceived();
+            emissionChecker.awaitNextExpectedValue();
             fail();
         } catch (AssertionError expected) {
             // it's okay
@@ -184,17 +184,17 @@ public class AbstractEmissionCheckerTest {
         publishSubject.onNext("1");
 
         // "1"
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         publishSubject.onNext("2");
 
         // "2"
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         publishSubject.onNext("3");
 
         // "3"
-        emissionChecker.assertThatNextExpectedValueReceived();
+        emissionChecker.awaitNextExpectedValue();
 
         // Should not throw exception
         emissionChecker.assertThatNoExpectedValuesLeft();
@@ -223,7 +223,7 @@ public class AbstractEmissionCheckerTest {
             emissionChecker.assertThatNoExpectedValuesLeft();
             fail();
         } catch (AssertionError expected) {
-            // it's okay, we didn't call emissionChecker.assertThatNextExpectedValueReceived()
+            // it's okay, we didn't call emissionChecker.awaitNextExpectedValue()
         } finally {
             subscription.unsubscribe();
         }


### PR DESCRIPTION
This PR fixes race condition in integration tests for `StorIOContentResolver`, probably this race condition caused troubles with emulator too.

Description:

Put into `ContentProvider` causes `Changes`, all tests inserts some data in the beginning and we didn't `await` until these inserts cause `Changes` on `RxBus`, so if changes arrive with some delay (on slow build machine, for example), it can break further checks in some tests.

Now I made `await` for changes after inserts.

@nikitin-da PTAL, you can try to re-launch this PR on Travis several times to check that it builds normally without race conditions.