### PR TITLE
Fixed wasUpdated

### DIFF
--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/PutResult.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/PutResult.java
@@ -78,7 +78,7 @@ public final class PutResult {
      * {@code false} otherwise.
      */
     public boolean wasUpdated() {
-        return numberOfRowsUpdated != null;
+        return numberOfRowsUpdated != null && numberOfRowsUpdated > 0;
     }
 
     /**

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/put/PutResult.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/put/PutResult.java
@@ -106,7 +106,7 @@ public class PutResult {
      * {@link com.pushtorefresh.storio.sqlite.StorIOSQLite}, {@code false} otherwise.
      */
     public boolean wasUpdated() {
-        return numberOfRowsUpdated != null;
+        return numberOfRowsUpdated != null && numberOfRowsUpdated > 0;
     }
 
     /**


### PR DESCRIPTION
Simple fix in case of such code : 
```
final int update = storIOSQLite
	.internal()
	.update(new UpdateQuery.Builder()
	.table(TABLE)
	.build(), cv);
return PutResult.newUpdateResult(update, TABLE);
```

since update() returns an int it's better to check > 0 on library side than client's