### PR TITLE
Reduce tests flakiness via awaiting changes after modifying operations on ContentProvider

### DIFF
--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/DeleteTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/DeleteTest.java
@@ -1,7 +1,12 @@
 package com.pushtorefresh.storio.contentresolver.integration;
 
+import android.support.annotation.NonNull;
+
 import com.pushtorefresh.storio.contentresolver.BuildConfig;
+import com.pushtorefresh.storio.contentresolver.Changes;
+import com.pushtorefresh.storio.contentresolver.operations.delete.DeleteResult;
 import com.pushtorefresh.storio.contentresolver.operations.delete.DeleteResults;
+import com.pushtorefresh.storio.test.AbstractEmissionChecker;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -9,10 +14,17 @@ import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
+
+import rx.Subscription;
+import rx.functions.Action1;
+import rx.schedulers.Schedulers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21)
@@ -20,21 +32,76 @@ public class DeleteTest extends IntegrationTest {
 
     @Test
     public void deleteOne() {
-        final User user = putUser();
-        oneUserInStorageCheck(user);
-        deleteUser(user);
-        noUsersInStorageCheck();
+        final User user = insertUser();
+        checkThatThereIsOnlyOneUserInStorage(user);
+
+        final Queue<Changes> expectedChanges = new LinkedList<Changes>();
+        expectedChanges.add(Changes.newInstance(UserMeta.CONTENT_URI));
+
+        final AbstractEmissionChecker<Changes> emissionChecker = new AbstractEmissionChecker<Changes>(expectedChanges) {
+            @NonNull
+            @Override
+            public Subscription subscribe() {
+                return storIOContentResolver
+                        .observeChangesOfUri(UserMeta.CONTENT_URI)
+                        .subscribeOn(Schedulers.io())
+                        .subscribe(new Action1<Changes>() {
+                            @Override
+                            public void call(Changes changes) {
+                                onNextObtained(changes);
+                            }
+                        });
+            }
+        };
+
+        final Subscription subscription = emissionChecker.subscribe();
+
+        final DeleteResult deleteResult = storIOContentResolver
+                .delete()
+                .object(user)
+                .prepare()
+                .executeAsBlocking();
+
+        assertEquals(1, deleteResult.numberOfRowsDeleted());
+
+        emissionChecker.awaitNextExpectedValue();
+        emissionChecker.assertThatNoExpectedValuesLeft();
+
+        subscription.unsubscribe();
+
+        checkThatThereAreNoUsersInStorage();
     }
 
     @Test
     public void deleteCollection() {
-        final List<User> allUsers = putUsers(10);
+        final List<User> allUsers = insertUsers(10);
 
         final List<User> usersToDelete = new ArrayList<User>();
 
-        for (int i = 0; i < allUsers.size(); i += 2) {  // Delete every second
+        final Queue<Changes> expectedChanges = new LinkedList<Changes>();
+
+        for (int i = 0; i < allUsers.size(); i += 2) {  // Delete every second user
             usersToDelete.add(allUsers.get(i));
+            expectedChanges.add(Changes.newInstance(UserMeta.CONTENT_URI));
         }
+
+        final AbstractEmissionChecker<Changes> emissionChecker = new AbstractEmissionChecker<Changes>(expectedChanges) {
+            @NonNull
+            @Override
+            public Subscription subscribe() {
+                return storIOContentResolver
+                        .observeChangesOfUri(UserMeta.CONTENT_URI)
+                        .subscribeOn(Schedulers.io())
+                        .subscribe(new Action1<Changes>() {
+                            @Override
+                            public void call(Changes changes) {
+                                onNextObtained(changes);
+                            }
+                        });
+            }
+        };
+
+        final Subscription subscription = emissionChecker.subscribe();
 
         final DeleteResults<User> deleteResults = storIOContentResolver
                 .delete()
@@ -42,9 +109,17 @@ public class DeleteTest extends IntegrationTest {
                 .prepare()
                 .executeAsBlocking();
 
-        final List<User> existUsers = getAllUsers();
+        for (User user : usersToDelete) {
+            assertTrue(deleteResults.wasDeleted(user));
+            emissionChecker.awaitNextExpectedValue();
+        }
 
-        assertNotNull(existUsers);
+        emissionChecker.assertThatNoExpectedValuesLeft();
+        subscription.unsubscribe();
+
+        final List<User> storedUsers = getAllUsers();
+
+        assertNotNull(storedUsers);
 
         for (User user : allUsers) {
             final boolean shouldBeDeleted = usersToDelete.contains(user);
@@ -53,7 +128,7 @@ public class DeleteTest extends IntegrationTest {
             assertEquals(shouldBeDeleted, deleteResults.wasDeleted(user));
 
             // Check that everything that should be kept exist
-            assertEquals(!shouldBeDeleted, existUsers.contains(user));
+            assertEquals(!shouldBeDeleted, storedUsers.contains(user));
         }
     }
 }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/InsertTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/InsertTest.java
@@ -21,14 +21,14 @@ public class InsertTest extends IntegrationTest {
 
     @Test
     public void insertOne() {
-        final User user = putUser();
-        oneUserInStorageCheck(user);
+        final User user = insertUser();
+        checkThatThereIsOnlyOneUserInStorage(user);
     }
 
     @Test
     public void insertCollection() {
-        final List<User> users = putUsers(3);
-        usersInStorageCheck(users);
+        final List<User> users = insertUsers(3);
+        checkThatTheseUsersInStorage(users);
     }
 
     @Test
@@ -36,10 +36,10 @@ public class InsertTest extends IntegrationTest {
         final User user = TestFactory.newUser();
 
         for (int i = 0; i < 2; i++) {
-            putUser(user);
-            oneUserInStorageCheck(user);
+            insertUser(user);
+            checkThatThereIsOnlyOneUserInStorage(user);
             deleteUser(user);
-            noUsersInStorageCheck();
+            checkThatThereAreNoUsersInStorage();
         }
     }
 
@@ -48,7 +48,7 @@ public class InsertTest extends IntegrationTest {
      */
     @Test
     public void insertCollectionWithCustomId() {
-        final List<User> users = putUsers(1);
+        final List<User> users = insertUsers(1);
         final User user = users.get(0);
 
         assertNotNull(user.id());

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/QueryTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/QueryTest.java
@@ -25,13 +25,13 @@ public class QueryTest extends IntegrationTest {
 
     @Test
     public void queryAll() {
-        final List<User> users = putUsers(3);
-        usersInStorageCheck(users);
+        final List<User> users = insertUsers(3);
+        checkThatTheseUsersInStorage(users);
     }
 
     @Test
     public void queryOneByField() {
-        final List<User> users = putUsers(3);
+        final List<User> users = insertUsers(3);
 
         for (User user : users) {
             final List<User> usersFromQuery = storIOContentResolver
@@ -58,7 +58,7 @@ public class QueryTest extends IntegrationTest {
         // Reverse sorting by email before inserting, for the purity of the experiment.
         Collections.reverse(users);
 
-        putUsers(users);
+        insertUsers(users);
 
         final List<User> usersFromQueryOrdered = storIOContentResolver
                 .get()
@@ -88,7 +88,7 @@ public class QueryTest extends IntegrationTest {
         // Sorting by email before inserting, for the purity of the experiment.
         Collections.sort(users);
 
-        putUsers(users);
+        insertUsers(users);
 
         final List<User> usersFromQueryOrdered = storIOContentResolver
                 .get()
@@ -113,7 +113,7 @@ public class QueryTest extends IntegrationTest {
 
     @Test
     public void queryProjection() {
-        final List<User> users = putUsers(3);
+        final List<User> users = insertUsers(3);
 
         final List<User> usersFromStorage = storIOContentResolver
                 .get()

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/UserMeta.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/UserMeta.java
@@ -30,8 +30,8 @@ class UserMeta {
             COLUMN_EMAIL + " TEXT NOT NULL" +
             ");";
 
-    static final String CONTENT_URI = "content://" + TestContentProvider.AUTHORITY + "/" + TABLE;
-
+    @NonNull
+    static final Uri CONTENT_URI = Uri.parse("content://" + TestContentProvider.AUTHORITY + "/" + TABLE);
 
     static final PutResolver<User> PUT_RESOLVER = new DefaultPutResolver<User>() {
         @NonNull


### PR DESCRIPTION
This PR should reduce frequency of failing builds on CI, now we waiting for `Changes` on the `Bus` in all tests that modify the `ContentProvider`.

@nikitin-da PTAL!

I'll relaunch CI several times to see if it fails.