### PR TITLE
Consistent behavior of PutResult.newUpdateResult() in case of number …

### DIFF
--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/PutResult.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/PutResult.java
@@ -4,6 +4,8 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
+
 /**
  * Immutable container for single result of Put Operation.
  */
@@ -19,6 +21,12 @@ public final class PutResult {
     private final Uri affectedUri;
 
     private PutResult(@Nullable Uri insertedUri, @Nullable Integer numberOfRowsUpdated, @NonNull Uri affectedUri) {
+        if (numberOfRowsUpdated != null && numberOfRowsUpdated < 1) {
+            throw new IllegalStateException("Number of rows updated must be > 0");
+        }
+
+        checkNotNull(affectedUri, "affectedUri must not be null");
+
         this.insertedUri = insertedUri;
         this.numberOfRowsUpdated = numberOfRowsUpdated;
         this.affectedUri = affectedUri;
@@ -33,13 +41,14 @@ public final class PutResult {
      */
     @NonNull
     public static PutResult newInsertResult(@NonNull Uri insertedUri, @NonNull Uri affectedUri) {
+        checkNotNull(insertedUri, "insertedUri must not be null");
         return new PutResult(insertedUri, null, affectedUri);
     }
 
     /**
      * Creates {@link PutResult} for update.
      *
-     * @param numberOfRowsUpdated number of rows that were updated.
+     * @param numberOfRowsUpdated number of rows that were updated, must be greater than 0.
      * @param affectedUri         Uri that was affected by update.
      * @return new {@link PutResult} instance.
      */
@@ -78,7 +87,7 @@ public final class PutResult {
      * {@code false} otherwise.
      */
     public boolean wasUpdated() {
-        return numberOfRowsUpdated != null && numberOfRowsUpdated > 0;
+        return numberOfRowsUpdated != null;
     }
 
     /**
@@ -105,7 +114,7 @@ public final class PutResult {
     /**
      * Gets number of updated rows.
      *
-     * @return null if nothing was updated or number of updated rows.
+     * @return {@code null} if nothing was updated or number of rows updated {@code (> 0)}.
      */
     @Nullable
     public Integer numberOfRowsUpdated() {

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/put/PutResultTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/put/PutResultTest.java
@@ -1,0 +1,114 @@
+package com.pushtorefresh.storio.contentresolver.operations.put;
+
+import android.net.Uri;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertSame;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+public class PutResultTest {
+
+    @Test
+    public void createInsertResult() {
+        final Uri insertedUri = mock(Uri.class);
+        final Uri affectedUri = mock(Uri.class);
+
+        final PutResult insertResult = PutResult.newInsertResult(insertedUri, affectedUri);
+
+        assertTrue(insertResult.wasInserted());
+        assertFalse(insertResult.wasUpdated());
+
+        assertFalse(insertResult.wasNotInserted());
+        assertTrue(insertResult.wasNotUpdated());
+
+        assertSame(insertedUri, insertResult.insertedUri());
+        assertSame(affectedUri, insertResult.affectedUri());
+
+        assertNull(insertResult.numberOfRowsUpdated());
+    }
+
+    @Test
+    public void shouldNotCreateInsertResultWithNullInsertedUri() {
+        try {
+            //noinspection ConstantConditions
+            PutResult.newInsertResult(null, mock(Uri.class));
+            fail();
+        } catch (NullPointerException expected) {
+            assertEquals("insertedUri must not be null", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldNotCreateInsertResultWithNullAffectedUri() {
+        try {
+            //noinspection ConstantConditions
+            PutResult.newInsertResult(mock(Uri.class), null);
+            fail();
+        } catch (NullPointerException expected) {
+            assertEquals("affectedUri must not be null", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void createUpdateResult() {
+        final int numberOfRowsUpdated = 10;
+        final Uri affectedUri = mock(Uri.class);
+
+        final PutResult updateResult = PutResult.newUpdateResult(numberOfRowsUpdated, affectedUri);
+
+        assertTrue(updateResult.wasUpdated());
+        assertFalse(updateResult.wasInserted());
+
+        assertFalse(updateResult.wasNotUpdated());
+        assertTrue(updateResult.wasNotInserted());
+
+        //noinspection ConstantConditions
+        assertEquals(numberOfRowsUpdated, (int) updateResult.numberOfRowsUpdated());
+        assertSame(affectedUri, updateResult.affectedUri());
+
+        assertNull(updateResult.insertedUri());
+    }
+
+    @Test
+    public void shouldNotCreateUpdateResultWith0RowsUpdated() {
+        try {
+            PutResult.newUpdateResult(0, mock(Uri.class));
+            fail();
+        } catch (IllegalStateException expected) {
+            assertEquals("Number of rows updated must be > 0", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldNotCreateUpdateResultWithNegativeNumberOfRowsUpdated() {
+        try {
+            PutResult.newUpdateResult(-1, mock(Uri.class));
+            fail();
+        } catch (IllegalStateException expected) {
+            assertEquals("Number of rows updated must be > 0", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldCreateUpdateResultWithOneRowUpdated() {
+        PutResult.newUpdateResult(1, mock(Uri.class)); // no exceptions should occur
+    }
+
+    @Test
+    public void shouldNotCreateUpdateResultWithNullAffectedUri() {
+        try {
+            //noinspection ConstantConditions
+            PutResult.newUpdateResult(1, null);
+            fail();
+        } catch (NullPointerException expected) {
+            assertEquals("affectedUri must not be null", expected.getMessage());
+        }
+    }
+
+}

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/operations/put/PutResultTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/operations/put/PutResultTest.java
@@ -1,0 +1,200 @@
+package com.pushtorefresh.storio.sqlite.operations.put;
+
+import android.support.annotation.NonNull;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class PutResultTest {
+
+    void checkCreateInsertResult(long insertedId, @NonNull Set<String> affectedTables, @NonNull PutResult insertResult) {
+        assertTrue(insertResult.wasInserted());
+        assertFalse(insertResult.wasUpdated());
+
+        assertFalse(insertResult.wasNotInserted());
+        assertTrue(insertResult.wasNotUpdated());
+
+        //noinspection ConstantConditions
+        assertEquals(insertedId, (long) insertResult.insertedId());
+        assertEquals(affectedTables, insertResult.affectedTables());
+
+        assertNull(insertResult.numberOfRowsUpdated());
+    }
+
+    @Test
+    public void createInsertResultWithSeveralAffectedTables() {
+        final int insertedId = 10;
+        final Set<String> affectedTables = new HashSet<String>(asList("table1", "table2", "table3"));
+
+        checkCreateInsertResult(
+                insertedId,
+                affectedTables,
+                PutResult.newInsertResult(insertedId, affectedTables)
+        );
+    }
+
+    @Test
+    public void createInsertResultWithOneAffectedTables() {
+        final int insertedId = 10;
+        final String affectedTable = "table";
+
+        checkCreateInsertResult(
+                insertedId,
+                singleton(affectedTable),
+                PutResult.newInsertResult(insertedId, affectedTable)
+        );
+    }
+
+    @Test
+    public void shouldNotCreateInsertResultWithNullAffectedTables() {
+        try {
+            //noinspection ConstantConditions
+            PutResult.newInsertResult(1, (Set<String>) null);
+            fail();
+        } catch (NullPointerException expected) {
+            assertEquals("affectedTables must not be null", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldNotCreateInsertResultWithEmptyAffectedTables() {
+        try {
+            PutResult.newInsertResult(1, new HashSet<String>());
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertEquals("affectedTables must contain at least one element", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldNotCreateInsertResultWithNullAffectedTable() {
+        try {
+            //noinspection ConstantConditions
+            PutResult.newInsertResult(1, (String) null);
+            fail();
+        } catch (NullPointerException expected) {
+            assertTrue(expected.getMessage().contains("affectedTable must not be null or empty, affectedTables = "));
+        }
+    }
+
+    @Test
+    public void shouldNotCreateInsertResultWithEmptyAffectedTable() {
+        try {
+            PutResult.newInsertResult(1, "");
+            fail();
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage().contains("affectedTable must not be null or empty, affectedTables = "));
+        }
+    }
+
+    void checkCreateUpdateResult(int numberOfRowsUpdated, @NonNull Set<String> affectedTables, @NonNull PutResult updateResult) {
+        assertTrue(updateResult.wasUpdated());
+        assertFalse(updateResult.wasInserted());
+
+        assertFalse(updateResult.wasNotUpdated());
+        assertTrue(updateResult.wasNotInserted());
+
+        //noinspection ConstantConditions
+        assertEquals(numberOfRowsUpdated, (int) updateResult.numberOfRowsUpdated());
+        assertEquals(affectedTables, updateResult.affectedTables());
+
+        assertNull(updateResult.insertedId());
+    }
+
+    @Test
+    public void createUpdateResultWithSeveralAffectedTables() {
+        final int numberOfRowsUpdated = 10;
+        final Set<String> affectedTables = new HashSet<String>(asList("table1", "table2", "table3"));
+
+        checkCreateUpdateResult(
+                numberOfRowsUpdated,
+                affectedTables,
+                PutResult.newUpdateResult(numberOfRowsUpdated, affectedTables)
+        );
+    }
+
+    @Test
+    public void createUpdateResultWithOneAffectedTable() {
+        final int numberOfRowsUpdated = 10;
+        final String affectedTable = "table";
+
+        checkCreateUpdateResult(
+                numberOfRowsUpdated,
+                singleton(affectedTable),
+                PutResult.newUpdateResult(numberOfRowsUpdated, affectedTable)
+        );
+    }
+
+    @Test
+    public void shouldNotCreateUpdateResultWith0RowsUpdated() {
+        try {
+            PutResult.newUpdateResult(0, "table");
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertEquals("Number of rows updated must be > 0", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldNotCreateUpdateResultWithNegativeNumberOfRowsUpdated() {
+        try {
+            PutResult.newUpdateResult(-1, "table");
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertEquals("Number of rows updated must be > 0", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldNotCreateUpdateResultWithNullAffectedTables() {
+        try {
+            //noinspection ConstantConditions
+            PutResult.newUpdateResult(1, (Set<String>) null);
+            fail();
+        } catch (NullPointerException expected) {
+            assertEquals("affectedTables must not be null", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldNotCreateUpdateResultWithEmptyAffectedTables() {
+        try {
+            PutResult.newUpdateResult(1, new HashSet<String>());
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertEquals("affectedTables must contain at least one element", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldNotCreateUpdateResultWithNullAffectedTable() {
+        try {
+            //noinspection ConstantConditions
+            PutResult.newUpdateResult(1, (String) null);
+            fail();
+        } catch (NullPointerException expected) {
+            assertTrue(expected.getMessage().contains("affectedTable must not be null or empty, affectedTables = "));
+        }
+    }
+
+
+    @Test
+    public void shouldNotCreateUpdateResultWithEmptyAffectedTable() {
+        try {
+            PutResult.newUpdateResult(1, "");
+            fail();
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage().contains("affectedTable must not be null or empty, affectedTables = "));
+        }
+    }
+}


### PR DESCRIPTION
…of rows updated < 1, tests

This PR makes behavior of `PutResult.newUpdateResult()` consistent with `SQLiteDatabase`, if number of rows updated < 1 -> throw exception.

Also, I've noticed that we didn't have tests on `PutResult`! So I've added them.

@nikitin-da PTAL!