### PR TITLE
Direct link to the blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ####Documentation:
 
-* [`Why we made StorIO`](https://engineering.pushtorefresh.com/)
+* [`Why we made StorIO`](https://engineering.pushtorefresh.com/2015/07/02/storio-modern-replacement-for-sqlitedatabase-and-contentresolver-apis/)
 * [`StorIO SQLite`](docs/StorIOSQLite.md)
 * [`StorIO ContentResolver`](docs/StorIOContentResolver.md)
 
@@ -203,6 +203,7 @@ API of `StorIOContentResolver` is same.
 
 ####Documentation:
 
+* [`Why we made StorIO`](https://engineering.pushtorefresh.com/2015/07/02/storio-modern-replacement-for-sqlitedatabase-and-contentresolver-apis/)
 * [`StorIO SQLite`](docs/StorIOSQLite.md)
 * [`StorIO ContentResolver`](docs/StorIOContentResolver.md)
 


### PR DESCRIPTION
Via Google Analytics on the [engineering.pushtorefresh.com](https://engineering.pushtorefresh.com) I noticed that we receive redirects from GitHub to the [engineering.pushtorefresh.com](https://engineering.pushtorefresh.com) instead of direct link to the post https://engineering.pushtorefresh.com/2015/07/02/storio-modern-replacement-for-sqlitedatabase-and-contentresolver-apis/

So I've fixed the link and also added it to the bottom of the README.

@nikitin-da PTAL