### PR TITLE
80% code coverage for StorIO-Test-Common

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,14 +15,26 @@ buildscript {
         // APT compile-time annotation processing
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
 
+        // Jacoco Test Coverage Plugin
+        // (addition to standard Jacoco plugin, allows us fail the build if coverage is not enough)
+        // https://github.com/palantir/gradle-jacoco-coverage
+        classpath 'com.palantir:jacoco-coverage:0.2.0'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
 
 allprojects {
+
     repositories {
         jcenter()
+    }
+
+    // Workaround for preventing Gradle from stealing focus from other apps
+    // https://gist.github.com/artem-zinnatullin/4c250e04636e25797165
+    tasks.withType(JavaForkOptions) {
+        jvmArgs '-Djava.awt.headless=true'
     }
 }
 
@@ -52,6 +64,7 @@ ext.libraries = [
         // Libraries for tests and sample app
         junit                          : 'junit:junit:4.12',
         mockitoCore                    : 'org.mockito:mockito-core:1.10.19',
+        equalsVerifier                 : 'nl.jqno.equalsverifier:equalsverifier:1.7.2',
         guava                          : 'com.google.guava:guava:18.0',
         robolectric                    : 'org.robolectric:robolectric:3.0-rc3',
 
@@ -81,9 +94,10 @@ ext.libraries = [
 project.ext.preDexLibs = !project.hasProperty('disablePreDex')
 
 subprojects {
+
     project.plugins.whenPluginAdded { plugin ->
-        if ("com.android.build.gradle.AppPlugin".equals(plugin.class.name)
-                || "com.android.build.gradle.LibraryPlugin".equals(plugin.class.name)) {
+        if ('com.android.build.gradle.AppPlugin'.equals(plugin.class.name)
+                || 'com.android.build.gradle.LibraryPlugin'.equals(plugin.class.name)) {
 
             // enable or disable pre-dexing
             project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs

--- a/ci.sh
+++ b/ci.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Please run it from root project directory
-./gradlew clean build checkstyle -PdisablePreDex
+./gradlew clean build jacocoReport checkstyle -PdisablePreDex

--- a/gradle/jacoco-android.gradle
+++ b/gradle/jacoco-android.gradle
@@ -1,0 +1,43 @@
+apply plugin: 'jacoco'
+apply plugin: 'jacoco-coverage'
+
+jacoco {
+    version '0.7.4.201502262128'
+}
+
+// JaCoCo Test Reports, thanks to Nenick
+task jacocoReport(type: JacocoReport, dependsOn: 'test') {
+    group = 'Reporting'
+    description = 'Generate Jacoco coverage reports after running tests.'
+
+    reports {
+        xml {
+            enabled true // coveralls
+            destination "${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml"
+        }
+
+        html {
+            enabled true
+            destination "${project.buildDir}/reports/jacoco/test/html"
+        }
+    }
+
+    // use hidden configuration, for details look into JacocoPlugin.groovy
+    jacocoClasspath = project.configurations['androidJacocoAnt']
+
+    // exclude auto-generated classes and tests
+    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*',
+                      'android/**/*.*']
+
+    def debugTree = fileTree(dir: "${project.buildDir}/intermediates/classes/debug", excludes: fileFilter)
+    def mainSrc = "${project.projectDir}/src/main/java"
+
+    sourceDirectories = files([mainSrc])
+    classDirectories = files([debugTree])
+    executionData = fileTree(dir: project.projectDir, includes: ['**/*.exec', '**/*.ec'])
+}
+
+jacocoCoverage {
+    // Enfore minimum code coverage of 80% for every Java file
+    fileThreshold 0.8
+}

--- a/storio-test-common/build.gradle
+++ b/storio-test-common/build.gradle
@@ -21,8 +21,9 @@ dependencies {
     provided libraries.supportAnnotations
     provided libraries.rxJava
 
+    compile libraries.mockitoCore
+
     testCompile libraries.junit
-    testCompile libraries.mockitoCore
 }
 
 task checkstyle(type: Checkstyle) {
@@ -36,3 +37,5 @@ task checkstyle(type: Checkstyle) {
 
     classpath = files()
 }
+
+apply from: '../gradle/jacoco-android.gradle'

--- a/storio-test-common/src/main/java/com/pushtorefresh/storio/test/Asserts.java
+++ b/storio-test-common/src/main/java/com/pushtorefresh/storio/test/Asserts.java
@@ -4,8 +4,6 @@ import android.support.annotation.NonNull;
 
 import java.util.List;
 
-import static java.util.Arrays.asList;
-
 public final class Asserts {
 
     private Asserts() {
@@ -28,11 +26,6 @@ public final class Asserts {
             // it's okay
         }
 
-        try {
-            list.addAll(asList("1", "2", "3"));
-            throw new AssertionError("List is not immutable: list = " + list);
-        } catch (UnsupportedOperationException expected) {
-            // it's okay
-        }
+        // All modify operations failed, list is probably immutable
     }
 }

--- a/storio-test-common/src/main/java/com/pushtorefresh/storio/test/PrivateConstructorChecker.java
+++ b/storio-test-common/src/main/java/com/pushtorefresh/storio/test/PrivateConstructorChecker.java
@@ -1,0 +1,130 @@
+package com.pushtorefresh.storio.test;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+
+public class PrivateConstructorChecker<T> {
+
+    @NonNull
+    private final Class<T> clazz;
+
+    @Nullable
+    private final Class<? extends Throwable> expectedTypeOfException;
+
+    @Nullable
+    private final String expectedExceptionMessage;
+
+    private PrivateConstructorChecker(@NonNull Class<T> clazz,
+                                      @Nullable Class<? extends Throwable> expectedTypeOfException,
+                                      @Nullable String expectedExceptionMessage) {
+        this.clazz = clazz;
+        this.expectedTypeOfException = expectedTypeOfException;
+        this.expectedExceptionMessage = expectedExceptionMessage;
+    }
+
+    public static class Builder<T> {
+
+        @NonNull
+        private final Class<T> clazz;
+
+        @Nullable
+        private Class<? extends Throwable> expectedTypeOfException;
+
+        @Nullable
+        private String expectedExceptionMessage;
+
+        Builder(@NonNull Class<T> clazz) {
+            this.clazz = clazz;
+        }
+
+        @NonNull
+        public Builder<T> expectedTypeOfException(@NonNull Class<? extends Throwable> expectedTypeOfException) {
+            this.expectedTypeOfException = expectedTypeOfException;
+            return this;
+        }
+
+        @NonNull
+        public Builder<T> expectedExceptionMessage(@Nullable String expectedExceptionMessage) {
+            this.expectedExceptionMessage = expectedExceptionMessage;
+            return this;
+        }
+
+        public void check() {
+            if (expectedExceptionMessage != null && expectedTypeOfException == null) {
+                throw new IllegalStateException("You can not set expected exception message " +
+                        "without expected exception type");
+            }
+
+            new PrivateConstructorChecker<T>(
+                    clazz,
+                    expectedTypeOfException,
+                    expectedExceptionMessage
+            ).check();
+        }
+    }
+
+    @NonNull
+    public static <T> Builder<T> forClass(@NonNull Class<T> clazz) {
+        return new Builder<T>(clazz);
+    }
+
+    public void check() {
+        Constructor constructor;
+
+        try {
+            constructor = clazz.getDeclaredConstructor();
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("Can not get default declared constructor for class = "
+                    + clazz,
+                    e
+            );
+        }
+
+        constructor.setAccessible(true);
+
+        if (!Modifier.isPrivate(constructor.getModifiers())) {
+            throw new AssertionError("Constructor must be private");
+        }
+
+        try {
+            constructor.newInstance();
+        } catch (InstantiationException e) {
+            throw new RuntimeException("Can not instantiate instance of " + clazz, e);
+        } catch (IllegalAccessException e) {
+            // Fixed by setAccessible(true)
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            final Throwable cause = e.getCause();
+
+            // It's okay case if we expect some exception from this constructor
+            if (expectedTypeOfException != null) {
+                if (!expectedTypeOfException.equals(cause.getClass())) {
+                    throw new IllegalStateException("Expected exception of type = "
+                            + expectedTypeOfException + ", but was exception of type = "
+                            + e
+                    );
+                }
+
+                if (expectedExceptionMessage != null) {
+                    if (!expectedExceptionMessage.equals(cause.getMessage())) {
+                        throw new IllegalStateException("Expected exception message = '"
+                                + expectedExceptionMessage + "', but was = '"
+                                + cause.getMessage() + "'",
+                                e
+                        );
+                    }
+                }
+
+                // Everything is okay
+            } else {
+                throw new IllegalStateException("No exception was expected", e);
+            }
+        } catch (IllegalArgumentException e) {
+            throw new RuntimeException("Looks like constructor of " + clazz + " is not default", e);
+        }
+    }
+}

--- a/storio-test-common/src/main/java/com/pushtorefresh/storio/test/ToStringChecker.java
+++ b/storio-test-common/src/main/java/com/pushtorefresh/storio/test/ToStringChecker.java
@@ -1,0 +1,167 @@
+package com.pushtorefresh.storio.test;
+
+import android.net.Uri;
+import android.support.annotation.NonNull;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static java.util.Collections.unmodifiableList;
+import static org.mockito.Mockito.mock;
+
+public class ToStringChecker<T> {
+
+    @NonNull
+    private final Class<T> clazz;
+
+    ToStringChecker(@NonNull Class<T> clazz) {
+        this.clazz = clazz;
+    }
+
+    public static <T> ToStringChecker.Builder<T> forClass(@NonNull Class<T> clazz) {
+        return new Builder<T>(clazz);
+    }
+
+    public static class Builder<T> {
+
+        @NonNull
+        private final Class<T> clazz;
+
+        Builder(@NonNull Class<T> clazz) {
+            this.clazz = clazz;
+        }
+
+        public void check() {
+            new ToStringChecker<T>(clazz).check();
+        }
+    }
+
+    public void check() {
+        try {
+            final T object = createObject();
+            final List<Field> fieldsForToString = getFieldsForToString();
+
+            writeSampleValuesToFields(object, fieldsForToString);
+
+            final String objectToString = object.toString();
+            verifyThatFieldsPresentedInToString(object, objectToString, fieldsForToString);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    @NonNull
+    private T createObject() {
+        Constructor[] constructors = clazz.getDeclaredConstructors();
+
+        for (Constructor constructor : constructors) {
+            try {
+                constructor.setAccessible(true);
+
+                List<Object> sampleParameters = new ArrayList<Object>();
+
+                for (Class parameterType : constructor.getParameterTypes()) {
+                    sampleParameters.add(createSampleValueOfType(parameterType));
+                }
+
+                //noinspection unchecked
+                return (T) constructor.newInstance(sampleParameters.toArray());
+            } catch (Exception uh) {
+                // No luck with this constructor, let's try another one
+            }
+        }
+
+        throw new IllegalStateException("Tried all declared constructors, no luck :(");
+    }
+
+    @NonNull
+    private List<Field> getFieldsForToString() {
+        Field[] allFields = clazz.getDeclaredFields();
+
+        List<Field> fieldsForToString = new ArrayList<Field>(allFields.length);
+
+        for (Field field : allFields) {
+            // Transient field should not be part of toString()
+            if (Modifier.isTransient(field.getModifiers())) {
+                continue;
+            }
+
+            if (field.getName().equals("$jacocoData")) {
+                // Jacoco coverage tool can add field for internal usage
+                // It wont affect release code, of course.
+                continue;
+            }
+
+            fieldsForToString.add(field);
+        }
+
+        return unmodifiableList(fieldsForToString);
+    }
+
+    private void writeSampleValuesToFields(@NonNull T object, @NonNull List<Field> fields) {
+        for (Field field : fields) {
+            field.setAccessible(true);
+            writeSampleValueToField(object, field);
+        }
+    }
+
+    private void writeSampleValueToField(@NonNull Object object, @NonNull Field field) {
+        final Object value = createSampleValueOfType(field.getType());
+
+        try {
+            field.set(object, value);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @NonNull
+    Object createSampleValueOfType(@NonNull Class<?> type) {
+        if (type.equals(Boolean.class) || type.equals(boolean.class)) {
+            return true;
+        } else if (type.equals(Integer.class) || type.equals(int.class)) {
+            return 1;
+        } else if (type.equals(Long.class) || type.equals(long.class)) {
+            return 1L;
+        } else if (type.equals(String.class)) {
+            return "some_string";
+        } else if (type.equals(List.class)) {
+            return asList("1", "2", "3");
+        } else if (type.equals(Map.class)) {
+            return singletonMap("map_key", "map_value");
+        } else if (type.equals(Set.class)) {
+            return singleton("set_item");
+        } else if (type.equals(Uri.class)) {
+            return mock(Uri.class);
+        } else {
+            throw new IllegalStateException("Can not set sample value to the field of type " + type);
+        }
+    }
+
+    private void verifyThatFieldsPresentedInToString(@NonNull T object, @NonNull String objectToString, @NonNull List<Field> fields) {
+        try {
+            for (Field field : fields) {
+                final String fieldValueToString = field.get(object).toString();
+
+                if (// For regular fields
+                        !objectToString.contains(field.getName() + "=" + fieldValueToString)
+                                // IDEA generates ='value' for Strings
+                                && !objectToString.contains(field.getName() + "='" + fieldValueToString)) {
+                    throw new AssertionError("toString() does not contain field = "
+                            + field.getName() + ", object = " + object);
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/storio-test-common/src/test/java/com/pushtorefresh/storio/test/AssertsTest.java
+++ b/storio-test-common/src/test/java/com/pushtorefresh/storio/test/AssertsTest.java
@@ -4,8 +4,26 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class AssertsTest {
+
+    @Test
+    public void constructorMustBePrivateAndThrowException() {
+        PrivateConstructorChecker
+                .forClass(Asserts.class)
+                .expectedTypeOfException(IllegalStateException.class)
+                .expectedExceptionMessage("No instances please.")
+                .check();
+    }
 
     @Test
     public void shouldAssertThatListIsImmutable() {
@@ -22,5 +40,41 @@ public class AssertsTest {
     @Test(expected = AssertionError.class)
     public void shouldNotAssertThatListIsImmutable() {
         Asserts.assertThatListIsImmutable(new ArrayList<Object>());
+    }
+
+    @Test
+    public void shouldCheckThatListIsImmutableByCallingAdd() {
+        //noinspection unchecked
+        List<Object> list = mock(List.class);
+
+        try {
+            Asserts.assertThatListIsImmutable(list);
+            fail();
+        } catch (AssertionError expected) {
+            assertEquals("List is not immutable: list = " + list, expected.getMessage());
+        }
+
+        verify(list).add(anyObject());
+        verifyNoMoreInteractions(list);
+    }
+
+    @Test
+    public void shouldCheckThatListIsImmutableByCallingRemove() {
+        //noinspection unchecked
+        List<Object> list = mock(List.class);
+
+        when(list.add(anyObject()))
+                .thenThrow(new UnsupportedOperationException("add() not supported"));
+
+        try {
+            Asserts.assertThatListIsImmutable(list);
+            fail();
+        } catch (AssertionError expected) {
+            assertEquals("List is not immutable: list = " + list, expected.getMessage());
+        }
+
+        verify(list).add(anyObject());
+        verify(list).remove(0);
+        verifyNoMoreInteractions(list);
     }
 }

--- a/storio-test-common/src/test/java/com/pushtorefresh/storio/test/ObservableBehaviorCheckerTest.java
+++ b/storio-test-common/src/test/java/com/pushtorefresh/storio/test/ObservableBehaviorCheckerTest.java
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import rx.Observable;
 import rx.functions.Action1;
 
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -14,11 +15,11 @@ import static org.mockito.Mockito.verify;
 
 public class ObservableBehaviorCheckerTest {
 
-    @SuppressWarnings("unchecked")
     @Test
     public void assertThatObservableEmitsOncePositive() {
         final String testString = "Test string";
         final Observable<String> testObservable = Observable.just(testString);
+        //noinspection unchecked
         final Action1<String> testAction = mock(Action1.class);
 
         new ObservableBehaviorChecker<String>()
@@ -47,5 +48,53 @@ public class ObservableBehaviorCheckerTest {
                         }
                     }
                 }).checkBehaviorOfObservable();
+    }
+
+    @Test
+    public void shouldDenyUsingNullObservable() {
+        try {
+            //noinspection ConstantConditions
+            new ObservableBehaviorChecker<Object>()
+                    .observable(null)
+                    .expectedNumberOfEmissions(1)
+                    .testAction(new Action1<Object>() {
+                        @Override
+                        public void call(Object o) {
+
+                        }
+                    }).checkBehaviorOfObservable();
+        } catch (NullPointerException expected) {
+            assertEquals("Please specify fields", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldDenyUsingNullExpectedNumberOfEmissions() {
+        try {
+            //noinspection ConstantConditions
+            new ObservableBehaviorChecker<Object>()
+                    .observable(Observable.just(new Object()))
+                    .testAction(new Action1<Object>() {
+                        @Override
+                        public void call(Object o) {
+
+                        }
+                    }).checkBehaviorOfObservable();
+        } catch (NullPointerException expected) {
+            assertEquals("Please specify fields", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldDenyUsingNullTestAction() {
+        try {
+            //noinspection ConstantConditions
+            new ObservableBehaviorChecker<Object>()
+                    .observable(Observable.just(new Object()))
+                    .expectedNumberOfEmissions(1)
+                    .checkBehaviorOfObservable();
+        } catch (NullPointerException expected) {
+            assertEquals("Please specify fields", expected.getMessage());
+        }
     }
 }

--- a/storio-test-common/src/test/java/com/pushtorefresh/storio/test/PrivateConstructionCheckerTest.java
+++ b/storio-test-common/src/test/java/com/pushtorefresh/storio/test/PrivateConstructionCheckerTest.java
@@ -1,0 +1,187 @@
+package com.pushtorefresh.storio.test;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class PrivateConstructionCheckerTest {
+
+    @Test
+    public void builderShouldPreventSettingExceptionMessageWithoutExceptionType() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(Object.class)
+                    .expectedExceptionMessage("test message")
+                    .check();
+
+            fail();
+        } catch (IllegalStateException expected) {
+            assertEquals(
+                    "You can not set expected exception message without expected exception type",
+                    expected.getMessage()
+            );
+        }
+    }
+
+    static class ClassWithoutDefaultConstructor {
+        private ClassWithoutDefaultConstructor(String someParam) {
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionIfClassDoesNotHaveDeclaredConstructors() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithoutDefaultConstructor.class)
+                    .check();
+
+            fail();
+        } catch (RuntimeException expected) {
+            assertEquals(
+                    "Can not get default declared constructor for class = " + ClassWithoutDefaultConstructor.class,
+                    expected.getMessage()
+            );
+
+            assertTrue(expected.getCause() instanceof NoSuchMethodException);
+        }
+    }
+
+    static class ClassWithPrivateConstructor {
+        private ClassWithPrivateConstructor() {
+        }
+    }
+
+    @Test
+    public void shouldAssertThatConstructorIsPrivateAndDoesNotThrowExceptions() {
+        PrivateConstructorChecker
+                .forClass(ClassWithPrivateConstructor.class)
+                .check();
+    }
+
+    static class ClassWithDefaultProtectedConstructor {
+        ClassWithDefaultProtectedConstructor() {
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseConstructorHasDefaultModifier() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithDefaultProtectedConstructor.class)
+                    .check();
+
+            fail();
+        } catch (AssertionError expected) {
+            assertEquals("Constructor must be private", expected.getMessage());
+        }
+    }
+
+    static class ClassWithProtectedConstructor {
+        ClassWithProtectedConstructor() {
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseConstructorHasProtectedModifier() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithProtectedConstructor.class)
+                    .check();
+
+            fail();
+        } catch (AssertionError expected) {
+            assertEquals("Constructor must be private", expected.getMessage());
+        }
+    }
+
+    static class ClassWithPublicConstructor {
+        ClassWithPublicConstructor() {
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseConstructorHasPublicModifier() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithPublicConstructor.class)
+                    .check();
+
+            fail();
+        } catch (AssertionError expected) {
+            assertEquals("Constructor must be private", expected.getMessage());
+        }
+    }
+
+    static class ClassWithConstructorThatThrowsException {
+        private ClassWithConstructorThatThrowsException() {
+            throw new IllegalStateException("test exception");
+        }
+    }
+
+    @Test
+    public void shouldCheckThatConstructorThrowsExceptionWithoutCheckingMessage() {
+        PrivateConstructorChecker
+                .forClass(ClassWithConstructorThatThrowsException.class)
+                .expectedTypeOfException(IllegalStateException.class)
+                .check();
+    }
+
+    @Test
+    public void shouldCheckThatConstructorThrowsExceptionWithExpectedMessage() {
+        PrivateConstructorChecker
+                .forClass(ClassWithConstructorThatThrowsException.class)
+                .expectedTypeOfException(IllegalStateException.class)
+                .expectedExceptionMessage("test exception")
+                .check();
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseTypeOfExpectedExceptionDoesNotMatch() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithConstructorThatThrowsException.class)
+                    .expectedTypeOfException(IllegalArgumentException.class) // Incorrect type
+                    .check();
+
+            fail();
+        } catch (IllegalStateException expected) {
+            assertEquals("Expected exception of type = class java.lang.IllegalArgumentException, " +
+                            "but was exception of type = java.lang.reflect.InvocationTargetException",
+                    expected.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseExpectedMessageDoesNotMatch() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithConstructorThatThrowsException.class)
+                    .expectedTypeOfException(IllegalStateException.class) // Correct type
+                    .expectedExceptionMessage("lol, not something that you've expected?") // Incorrect message
+                    .check();
+
+            fail();
+        } catch (IllegalStateException expected) {
+            assertEquals("Expected exception message = 'lol, not something that you've expected?', " +
+                            "but was = 'test exception'",
+                    expected.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseConstructorThrownUnexpectedException() {
+        try {
+            PrivateConstructorChecker
+                    .forClass(ClassWithConstructorThatThrowsException.class)
+                    .check(); // We don't expect exception, but it will be thrown
+
+            fail();
+        } catch (IllegalStateException expected) {
+            assertEquals("No exception was expected", expected.getMessage());
+        }
+    }
+}

--- a/storio-test-common/src/test/java/com/pushtorefresh/storio/test/ToStringCheckerTest.java
+++ b/storio-test-common/src/test/java/com/pushtorefresh/storio/test/ToStringCheckerTest.java
@@ -1,0 +1,144 @@
+package com.pushtorefresh.storio.test;
+
+import android.net.Uri;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ToStringCheckerTest {
+
+    static class ClassWithCorrectToString {
+
+        int a;
+        String b;
+
+        @Override
+        public String toString() {
+            return "ClassWithCorrectToString{" +
+                    "a=" + a +
+                    ", b='" + b + '\'' +
+                    '}';
+        }
+    }
+
+    @Test
+    public void shouldCheckSuccessfully() {
+        ToStringChecker
+                .forClass(ClassWithCorrectToString.class)
+                .check();
+    }
+
+    static class ClassWithIncorrectToString {
+        int a;
+        String b;
+
+        @Override
+        public String toString() {
+            return "ClassWithIncorrectToString{" +
+                    "b='" + b + '\'' +
+                    '}';
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseOneOfTheFieldsIsNotIncludedIntoToString() {
+        try {
+            ToStringChecker
+                    .forClass(ClassWithIncorrectToString.class)
+                    .check();
+
+            fail();
+        } catch (AssertionError expected) {
+            assertEquals("toString() does not contain field = a, " +
+                    "object = ClassWithIncorrectToString{b='some_string'}",
+                    expected.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void shouldCreateSampleValueOfPrimitiveInt() {
+        Object sample = new ToStringChecker<Object>(Object.class)
+                .createSampleValueOfType(int.class);
+
+        assertEquals(1, sample);
+    }
+
+    @Test
+    public void shouldCreateSampleValueOfInteger() {
+        Object sample = new ToStringChecker<Object>(Object.class)
+                .createSampleValueOfType(Integer.class);
+
+        assertEquals(1, sample);
+    }
+
+    @Test
+    public void shouldCreateSampleValueOfPrimitiveLong() {
+        Object sample = new ToStringChecker<Object>(Object.class)
+                .createSampleValueOfType(long.class);
+
+        assertEquals(1L, sample);
+    }
+
+    @Test
+    public void shouldCreateSampleValueOfLong() {
+        Object sample = new ToStringChecker<Object>(Object.class)
+                .createSampleValueOfType(Long.class);
+
+        assertEquals(1L, sample);
+    }
+
+    @Test
+    public void shouldCreateSampleValueOfString() {
+        Object sample = new ToStringChecker<Object>(Object.class)
+                .createSampleValueOfType(String.class);
+
+        assertEquals("some_string", sample);
+    }
+
+    @Test
+    public void shouldCreateSampleValueOfList() {
+        Object sample = new ToStringChecker<Object>(Object.class)
+                .createSampleValueOfType(List.class);
+
+        //noinspection AssertEqualsBetweenInconvertibleTypes
+        assertEquals(asList("1", "2", "3"), sample);
+    }
+
+    @Test
+    public void shouldCreateSampleValueOfMap() {
+        Object sample = new ToStringChecker<Object>(Object.class)
+                .createSampleValueOfType(Map.class);
+
+        //noinspection AssertEqualsBetweenInconvertibleTypes
+        assertEquals(singletonMap("map_key", "map_value"), sample);
+    }
+
+    @Test
+    public void shouldCreateSampleValueOfSet() {
+        Object sample = new ToStringChecker<Object>(Object.class)
+                .createSampleValueOfType(Set.class);
+
+        //noinspection AssertEqualsBetweenInconvertibleTypes
+        assertEquals(singleton("set_item"), sample);
+    }
+
+    @Test
+    public void shouldCreateSampleValueOfUri() {
+        Object sample = new ToStringChecker<Object>(Object.class)
+                .createSampleValueOfType(Uri.class);
+
+        // We can not check equality of Uri instance here…
+        assertTrue(sample instanceof Uri);
+    }
+}


### PR DESCRIPTION
Part of #450!

This PR adds Jacoco code coverage plugin to the project and enforces 80% code coverage for StorIO-Test-Common.

Also, as part of the improvement of code coverage in StorIO project this PR introduces two major utility classes `PrivateConstructorChecker` and `ToStringChecker`.

@nikitin-da PTAL! 