### PR TITLE
80% code coverage for StorIO-Content-Resolver

### DIFF
--- a/storio-content-resolver/build.gradle
+++ b/storio-content-resolver/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
     testCompile libraries.junit
     testCompile libraries.mockitoCore
+    testCompile libraries.equalsVerifier
     testCompile libraries.storIOTestCommon
     testCompile libraries.robolectric
 }
@@ -45,4 +46,5 @@ task checkstyle(type: Checkstyle) {
     classpath = files()
 }
 
+apply from: '../gradle/jacoco-android.gradle'
 apply from: '../gradle/publish-android-lib.gradle'

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetCursor.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetCursor.java
@@ -119,7 +119,7 @@ public final class PreparedGetCursor extends PreparedGet<Cursor> {
      */
     public static final class CompleteBuilder {
 
-        private static final GetResolver<Cursor> STANDARD_GET_RESOLVER = new DefaultGetResolver<Cursor>() {
+        static final GetResolver<Cursor> STANDARD_GET_RESOLVER = new DefaultGetResolver<Cursor>() {
             @NonNull
             @Override
             public Cursor mapFromCursor(@NonNull Cursor cursor) {

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetListOfObjects.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetListOfObjects.java
@@ -61,7 +61,6 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<List<T>> {
      * @return non-null, immutable {@link List} with mapped results, list can be empty.
      */
     @WorkerThread
-    @SuppressWarnings("unchecked") // for empty list
     @NonNull
     @Override
     public List<T> executeAsBlocking() {
@@ -88,6 +87,7 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<List<T>> {
                 final int count = cursor.getCount();
 
                 if (count == 0) {
+                    //noinspection unchecked
                     return EMPTY_LIST; // it's immutable
                 } else {
                     final List<T> list = new ArrayList<T>(count);

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/DefaultPutResolver.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/DefaultPutResolver.java
@@ -61,23 +61,23 @@ public abstract class DefaultPutResolver<T> extends PutResolver<T> {
                 .whereArgs((Object[]) nullableArrayOfStrings(updateQuery.whereArgs()))
                 .build();
 
-        final Cursor cursor = storIOContentResolver.internal().query(query);
+        final StorIOContentResolver.Internal internal = storIOContentResolver.internal();
+
+        final Cursor cursor = internal.query(query);
 
         try {
             final ContentValues contentValues = mapToContentValues(object);
 
-            if (cursor == null || cursor.getCount() == 0) {
+            if (cursor.getCount() == 0) {
                 final InsertQuery insertQuery = mapToInsertQuery(object);
-                final Uri insertedUri = storIOContentResolver.internal().insert(insertQuery, contentValues);
+                final Uri insertedUri = internal.insert(insertQuery, contentValues);
                 return PutResult.newInsertResult(insertedUri, insertQuery.uri());
             } else {
-                final int numberOfRowsUpdated = storIOContentResolver.internal().update(updateQuery, contentValues);
+                final int numberOfRowsUpdated = internal.update(updateQuery, contentValues);
                 return PutResult.newUpdateResult(numberOfRowsUpdated, updateQuery.uri());
             }
         } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
+            cursor.close();
         }
     }
 }

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/PutResults.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/PutResults.java
@@ -16,11 +16,13 @@ public final class PutResults<T> {
     @NonNull
     private final Map<T, PutResult> results;
 
+    // Marked as transient to correct equals/hashCode/toString checks (tests)
     @Nullable
-    private volatile Integer numberOfInsertsCache;
+    private volatile transient Integer numberOfInsertsCache;
 
+    // Marked as transient to correct equals/hashCode/toString checks (tests)
     @Nullable
-    private volatile Integer numberOfUpdatesCache;
+    private volatile transient Integer numberOfUpdatesCache;
 
     private PutResults(@NonNull Map<T, PutResult> putResults) {
         this.results = Collections.unmodifiableMap(putResults);

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/DeleteQuery.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/DeleteQuery.java
@@ -205,10 +205,6 @@ public final class DeleteQuery {
          */
         @NonNull
         public DeleteQuery build() {
-            if (where == null && whereArgs != null && !whereArgs.isEmpty()) {
-                throw new IllegalStateException("You can not use whereArgs without where clause");
-            }
-
             return new DeleteQuery(
                     uri,
                     where,

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/Query.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/Query.java
@@ -16,7 +16,7 @@ import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullListO
  * <p>
  * Instances of this class are Immutable.
  */
-public class Query {
+public final class Query {
 
     @NonNull
     private final Uri uri;

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/UpdateQuery.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/UpdateQuery.java
@@ -95,6 +95,15 @@ public final class UpdateQuery {
         return result;
     }
 
+    @Override
+    public String toString() {
+        return "UpdateQuery{" +
+                "uri=" + uri +
+                ", where='" + where + '\'' +
+                ", whereArgs=" + whereArgs +
+                '}';
+    }
+
     /**
      * Creates new builder for {@link UpdateQuery}.
      *
@@ -203,10 +212,6 @@ public final class UpdateQuery {
          */
         @NonNull
         public UpdateQuery build() {
-            if (where == null && whereArgs != null && !whereArgs.isEmpty()) {
-                throw new IllegalStateException("You can not use whereArgs without where clause");
-            }
-
             return new UpdateQuery(
                     uri,
                     where,

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/ChangesTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/ChangesTest.java
@@ -2,15 +2,24 @@ package com.pushtorefresh.storio.contentresolver;
 
 import android.net.Uri;
 
+import com.pushtorefresh.storio.test.ToStringChecker;
+
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.util.HashSet;
 import java.util.Set;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+@RunWith(RobolectricGradleTestRunner.class) // Required for correct Uri impl
+@Config(constants = BuildConfig.class, sdk = 21)
 public class ChangesTest {
 
     @SuppressWarnings("ConstantConditions")
@@ -43,5 +52,21 @@ public class ChangesTest {
         final Changes changes = Changes.newInstance(affectedUris);
 
         assertEquals(affectedUris, changes.affectedUris());
+    }
+
+    @Test
+    public void verifyEqualsAndHashCodeImplementation() {
+        EqualsVerifier
+                .forClass(Changes.class)
+                .allFieldsShouldBeUsed()
+                .withPrefabValues(Uri.class, Uri.parse("content://1"), Uri.parse("content://2"))
+                .verify();
+    }
+
+    @Test
+    public void checkToStringImplementation() {
+        ToStringChecker
+                .forClass(Changes.class)
+                .check();
     }
 }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/IntegrationTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/IntegrationTest.java
@@ -321,8 +321,8 @@ public abstract class IntegrationTest {
 
     @NonNull
     PreparedGetCursor createQueryWithNullResult() {
-
         final ContentResolver internalContentResolver = mock(ContentResolver.class);
+
         when(internalContentResolver
                 .query(any(Uri.class),
                         any(String[].class),
@@ -343,7 +343,9 @@ public abstract class IntegrationTest {
         return defaultStorIOContentResolver
                 .get()
                 .cursor()
-                .withQuery(mock(Query.class))
+                .withQuery(Query.builder()
+                        .uri(mock(Uri.class))
+                        .build())
                 .prepare();
     }
 }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/QueryTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/QueryTest.java
@@ -151,6 +151,7 @@ public class QueryTest extends IntegrationTest {
     @Test
     public void shouldThrowExceptionIfCursorNullBlocking() {
         final PreparedGetCursor queryWithNullResult = createQueryWithNullResult();
+
         try {
             queryWithNullResult.executeAsBlocking();
             fail("StorIOException should be thrown");

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/delete/DeleteResultTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/delete/DeleteResultTest.java
@@ -2,15 +2,25 @@ package com.pushtorefresh.storio.contentresolver.operations.delete;
 
 import android.net.Uri;
 
+import com.pushtorefresh.storio.contentresolver.BuildConfig;
+import com.pushtorefresh.storio.test.ToStringChecker;
+
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.util.HashSet;
 import java.util.Set;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+@RunWith(RobolectricGradleTestRunner.class) // Required for correct Uri impl
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DeleteResultTest {
 
     @SuppressWarnings("ConstantConditions")
@@ -49,5 +59,21 @@ public class DeleteResultTest {
 
         final DeleteResult deleteResult = DeleteResult.newInstance(3, affectedUris);
         assertEquals(affectedUris, deleteResult.affectedUris());
+    }
+
+    @Test
+    public void verifyEqualsAndHashCodeImplementation() {
+        EqualsVerifier
+                .forClass(DeleteResult.class)
+                .allFieldsShouldBeUsed()
+                .withPrefabValues(Uri.class, Uri.parse("content://1"), Uri.parse("content://2"))
+                .verify();
+    }
+
+    @Test
+    public void checkToStringImplementation() {
+        ToStringChecker
+                .forClass(DeleteResult.class)
+                .check();
     }
 }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/delete/DeleteResultsTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/delete/DeleteResultsTest.java
@@ -2,14 +2,26 @@ package com.pushtorefresh.storio.contentresolver.operations.delete;
 
 import android.net.Uri;
 
+import com.pushtorefresh.storio.contentresolver.BuildConfig;
+import com.pushtorefresh.storio.test.ToStringChecker;
+
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+@RunWith(RobolectricGradleTestRunner.class) // Required for correct Uri impl
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DeleteResultsTest {
 
     @SuppressWarnings("ConstantConditions")
@@ -19,13 +31,54 @@ public class DeleteResultsTest {
     }
 
     @Test
-    public void results() {
+    public void resultsShouldBeEqual() {
         final Map<String, DeleteResult> results = new HashMap<String, DeleteResult>();
-        results.put("testString", DeleteResult.newInstance(1, mock(Uri.class)));
-        results.put("testString", DeleteResult.newInstance(1, mock(Uri.class)));
+        results.put("testString1", DeleteResult.newInstance(1, mock(Uri.class)));
+        results.put("testString2", DeleteResult.newInstance(1, mock(Uri.class)));
 
         final DeleteResults<String> deleteResults = DeleteResults.newInstance(results);
 
         assertEquals(results, deleteResults.results());
+    }
+
+    @Test
+    public void checkWasDeleted() {
+        final Map<String, DeleteResult> results = new HashMap<String, DeleteResult>();
+        results.put("testString1", DeleteResult.newInstance(1, Uri.parse("content://testUri")));
+        results.put("testString2", DeleteResult.newInstance(1, Uri.parse("content://testUri")));
+
+        final DeleteResults<String> deleteResults = DeleteResults.newInstance(results);
+
+        assertTrue(deleteResults.wasDeleted("testString1"));
+        assertTrue(deleteResults.wasDeleted("testString2"));
+        assertFalse(deleteResults.wasDeleted("testString3"));
+    }
+
+    @Test
+    public void checkWasNotDeleted() {
+        final Map<String, DeleteResult> results = new HashMap<String, DeleteResult>();
+        results.put("testString1", DeleteResult.newInstance(1, Uri.parse("content://testUri")));
+        results.put("testString2", DeleteResult.newInstance(1, Uri.parse("content://testUri")));
+
+        final DeleteResults<String> deleteResults = DeleteResults.newInstance(results);
+
+        assertFalse(deleteResults.wasNotDeleted("testString1"));
+        assertFalse(deleteResults.wasNotDeleted("testString2"));
+        assertTrue(deleteResults.wasNotDeleted("testString3"));
+    }
+
+    @Test
+    public void verifyEqualsAndHashCodeImplementation() {
+        EqualsVerifier
+                .forClass(DeleteResults.class)
+                .allFieldsShouldBeUsed()
+                .verify();
+    }
+
+    @Test
+    public void checkToStringImplementation() {
+        ToStringChecker
+                .forClass(DeleteResults.class)
+                .check();
     }
 }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetCursorTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetCursorTest.java
@@ -1,10 +1,20 @@
 package com.pushtorefresh.storio.contentresolver.operations.get;
 
 import android.database.Cursor;
+import android.net.Uri;
+
+import com.pushtorefresh.storio.contentresolver.StorIOContentResolver;
+import com.pushtorefresh.storio.contentresolver.queries.Query;
 
 import org.junit.Test;
 
 import rx.Observable;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class PreparedGetCursorTest {
 
@@ -38,5 +48,40 @@ public class PreparedGetCursorTest {
                 .take(1);
 
         getStub.verifyQueryBehaviorForCursor(cursorObservable);
+    }
+
+    @Test
+    public void shouldUseStandardGetResolverWithoutExplicitlyPassed() {
+        StorIOContentResolver storIOContentResolver = mock(StorIOContentResolver.class);
+
+        StorIOContentResolver.Internal internal = mock(StorIOContentResolver.Internal.class);
+
+        when(storIOContentResolver.internal()).thenReturn(internal);
+
+        Query query = Query.builder()
+                .uri(mock(Uri.class))
+                .build();
+
+        new PreparedGetCursor.Builder(storIOContentResolver)
+                .withQuery(query)
+                .prepare()
+                .executeAsBlocking();
+
+        verify(storIOContentResolver).internal();
+        verify(internal).query(query);
+
+        verifyNoMoreInteractions(storIOContentResolver, internal);
+    }
+
+    @Test
+    public void checkThatStandardGetResolverDoesNotModifyCursor() {
+        Cursor cursor = mock(Cursor.class);
+
+        Cursor cursorAfterMap = PreparedGetCursor
+                .CompleteBuilder
+                .STANDARD_GET_RESOLVER
+                .mapFromCursor(cursor);
+
+        assertEquals(cursor, cursorAfterMap);
     }
 }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetListOfObjectsTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetListOfObjectsTest.java
@@ -1,5 +1,6 @@
 package com.pushtorefresh.storio.contentresolver.operations.get;
 
+import android.database.Cursor;
 import android.net.Uri;
 
 import com.pushtorefresh.storio.StorIOException;
@@ -17,6 +18,7 @@ import java.util.List;
 import rx.Observable;
 import rx.observers.TestSubscriber;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -108,7 +110,7 @@ public class PreparedGetListOfObjectsTest {
             final PreparedGet<List<TestItem>> preparedGet = storIOContentResolver
                     .get()
                     .listOfObjects(TestItem.class)
-                    .withQuery(mock(Query.class))
+                    .withQuery(Query.builder().uri(mock(Uri.class)).build())
                     .prepare();
 
             try {
@@ -143,7 +145,7 @@ public class PreparedGetListOfObjectsTest {
             storIOContentResolver
                     .get()
                     .listOfObjects(TestItem.class)
-                    .withQuery(mock(Query.class))
+                    .withQuery(Query.builder().uri(mock(Uri.class)).build())
                     .prepare()
                     .createObservable()
                     .subscribe(testSubscriber);
@@ -159,6 +161,55 @@ public class PreparedGetListOfObjectsTest {
             verify(storIOContentResolver).observeChangesOfUri(any(Uri.class));
 
             verifyNoMoreInteractions(storIOContentResolver, internal);
+        }
+    }
+
+    // With Enclosed runner we can not have tests in root class
+    public static class OtherTests {
+
+        @Test
+        public void shouldCloseCursorInCaseOfException() {
+            StorIOContentResolver storIOContentResolver = mock(StorIOContentResolver.class);
+
+            Query query = Query.builder()
+                    .uri(mock(Uri.class))
+                    .build();
+
+            //noinspection unchecked
+            GetResolver<Object> getResolver = mock(GetResolver.class);
+
+            Cursor cursor = mock(Cursor.class);
+
+            when(getResolver.performGet(storIOContentResolver, query))
+                    .thenReturn(cursor);
+
+            when(getResolver.mapFromCursor(cursor))
+                    .thenThrow(new IllegalStateException("Breaking execution"));
+
+            when(cursor.getCount()).thenReturn(1);
+
+            when(cursor.moveToNext()).thenReturn(true);
+
+            try {
+                new PreparedGetListOfObjects.Builder<Object>(storIOContentResolver, Object.class)
+                        .withQuery(query)
+                        .withGetResolver(getResolver)
+                        .prepare()
+                        .executeAsBlocking();
+
+                fail();
+            } catch (StorIOException expected) {
+                IllegalStateException cause = (IllegalStateException) expected.getCause();
+                assertEquals("Breaking execution", cause.getMessage());
+
+                // Main check: in case of exception cursor must be closed
+                verify(cursor).close();
+
+                verify(cursor).getCount();
+                verify(cursor).moveToNext();
+
+                verifyNoMoreInteractions(storIOContentResolver, cursor);
+            }
         }
     }
 }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/put/DefaultPutResolverTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/put/DefaultPutResolverTest.java
@@ -26,8 +26,10 @@ import static junit.framework.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class DefaultPutResolverTest {
@@ -97,22 +99,22 @@ public class DefaultPutResolverTest {
         final PutResult putResult = putResolver.performPut(storIOContentResolver, testItem);
 
         // checks that it asks db for results
-        verify(internal, times(1)).query(eq(expectedQuery));
+        verify(internal).query(eq(expectedQuery));
 
         // checks that cursor was closed
-        verify(cursor, times(1)).close();
+        verify(cursor).close();
 
         // only one query should occur
-        verify(internal, times(1)).query(any(Query.class));
+        verify(internal).query(any(Query.class));
 
         // checks that required insert was performed
-        verify(internal, times(1)).insert(eq(expectedInsertQuery), eq(expectedContentValues));
+        verify(internal).insert(eq(expectedInsertQuery), eq(expectedContentValues));
 
         // only one insert should occur
-        verify(internal, times(1)).insert(any(InsertQuery.class), any(ContentValues.class));
+        verify(internal).insert(any(InsertQuery.class), any(ContentValues.class));
 
         // no updates should occur
-        verify(internal, times(0)).update(any(UpdateQuery.class), any(ContentValues.class));
+        verify(internal, never()).update(any(UpdateQuery.class), any(ContentValues.class));
 
         // put result checks
         assertTrue(putResult.wasInserted());
@@ -129,7 +131,7 @@ public class DefaultPutResolverTest {
     public void update() {
         final StorIOContentResolver storIOContentResolver = mock(StorIOContentResolver.class);
         final StorIOContentResolver.Internal internal = mock(StorIOContentResolver.Internal.class);
-        final TestItem testItem = new TestItem(null); // item with some id, should be updated
+        final TestItem testItem = new TestItem(1L); // item with some id, should be updated
 
         when(storIOContentResolver.internal())
                 .thenReturn(internal);
@@ -215,12 +217,180 @@ public class DefaultPutResolverTest {
         assertNull(putResult.insertedUri());
     }
 
+    @Test
+    public void shouldCloseCursorIfUpdateThrowsException() {
+        final StorIOContentResolver storIOContentResolver = mock(StorIOContentResolver.class);
+        final StorIOContentResolver.Internal internal = mock(StorIOContentResolver.Internal.class);
+
+        when(storIOContentResolver.internal())
+                .thenReturn(internal);
+
+        final TestItem testItem = new TestItem(1L); // item with some id, should be updated
+
+        final Query expectedQuery = Query.builder()
+                .uri(TestItem.CONTENT_URI)
+                .where(TestItem.COLUMN_ID + " = ?")
+                .whereArgs(testItem.getId())
+                .build();
+
+        final Cursor cursor = mock(Cursor.class);
+
+        when(internal.query(eq(expectedQuery)))
+                .thenReturn(cursor);
+
+        when(cursor.getCount())
+                .thenReturn(1); // One result -> update should be performed
+
+        final UpdateQuery expectedUpdateQuery = UpdateQuery.builder()
+                .uri(TestItem.CONTENT_URI)
+                .where(TestItem.COLUMN_ID + " = ?")
+                .whereArgs(testItem.getId())
+                .build();
+
+        when(internal.update(eq(expectedUpdateQuery), any(ContentValues.class)))
+                .thenThrow(new IllegalStateException("Fake exception from ContentResolver"));
+
+        final PutResolver<TestItem> putResolver = new DefaultPutResolver<TestItem>() {
+            @NonNull
+            @Override
+            protected InsertQuery mapToInsertQuery(@NonNull TestItem object) {
+                return InsertQuery.builder()
+                        .uri(TestItem.CONTENT_URI)
+                        .build();
+            }
+
+            @NonNull
+            @Override
+            protected UpdateQuery mapToUpdateQuery(@NonNull TestItem object) {
+                return UpdateQuery.builder()
+                        .uri(TestItem.CONTENT_URI)
+                        .where(TestItem.COLUMN_ID + " = ?")
+                        .whereArgs(object.getId())
+                        .build();
+            }
+
+            @NonNull
+            @Override
+            protected ContentValues mapToContentValues(@NonNull TestItem object) {
+                return TestItem.MAP_TO_CONTENT_VALUES.call(object);
+            }
+        };
+
+
+        try {
+            putResolver.performPut(storIOContentResolver, testItem);
+            fail();
+        } catch (IllegalStateException expected) {
+            assertEquals("Fake exception from ContentResolver", expected.getMessage());
+
+            verify(storIOContentResolver).internal();
+
+            // Checks that it asks actual ContentResolver for results
+            verify(internal).query(eq(expectedQuery));
+
+            verify(cursor).getCount();
+
+            // Cursor must be closed in case of exception!
+            verify(cursor).close();
+
+            verify(internal).update(eq(expectedUpdateQuery), any(ContentValues.class));
+
+            verifyNoMoreInteractions(storIOContentResolver, internal, cursor);
+        }
+    }
+
+    @Test
+    public void shouldCloseCursorIfInsertThrowsException() {
+        final StorIOContentResolver storIOContentResolver = mock(StorIOContentResolver.class);
+        final StorIOContentResolver.Internal internal = mock(StorIOContentResolver.Internal.class);
+
+        when(storIOContentResolver.internal())
+                .thenReturn(internal);
+
+        final TestItem testItem = new TestItem(null); // item without id, should be inserted
+
+        final Query expectedQuery = Query.builder()
+                .uri(TestItem.CONTENT_URI)
+                .where(TestItem.COLUMN_ID + " = ?")
+                .whereArgs(testItem.getId())
+                .build();
+
+        final Cursor cursor = mock(Cursor.class);
+
+        when(internal.query(eq(expectedQuery)))
+                .thenReturn(cursor);
+
+        when(cursor.getCount())
+                .thenReturn(0); // No results -> insert should be performed
+
+        final InsertQuery expectedInsertQuery = InsertQuery.builder()
+                .uri(TestItem.CONTENT_URI)
+                .build();
+
+        when(internal.insert(eq(expectedInsertQuery), any(ContentValues.class)))
+                .thenThrow(new IllegalStateException("Fake exception from ContentResolver"));
+
+        final PutResolver<TestItem> putResolver = new DefaultPutResolver<TestItem>() {
+            @NonNull
+            @Override
+            protected InsertQuery mapToInsertQuery(@NonNull TestItem object) {
+                return InsertQuery.builder()
+                        .uri(TestItem.CONTENT_URI)
+                        .build();
+            }
+
+            @NonNull
+            @Override
+            protected UpdateQuery mapToUpdateQuery(@NonNull TestItem object) {
+                return UpdateQuery.builder()
+                        .uri(TestItem.CONTENT_URI)
+                        .where(TestItem.COLUMN_ID + " = ?")
+                        .whereArgs(object.getId())
+                        .build();
+            }
+
+            @NonNull
+            @Override
+            protected ContentValues mapToContentValues(@NonNull TestItem object) {
+                return TestItem.MAP_TO_CONTENT_VALUES.call(object);
+            }
+        };
+
+
+        try {
+            putResolver.performPut(storIOContentResolver, testItem);
+            fail();
+        } catch (IllegalStateException expected) {
+            assertEquals("Fake exception from ContentResolver", expected.getMessage());
+
+            verify(storIOContentResolver).internal();
+
+            // Checks that it asks actual ContentResolver for results
+            verify(internal).query(eq(expectedQuery));
+
+            verify(cursor).getCount();
+
+            // Cursor must be closed in case of exception!
+            verify(cursor).close();
+
+            verify(internal).insert(eq(expectedInsertQuery), any(ContentValues.class));
+
+            verifyNoMoreInteractions(storIOContentResolver, internal, cursor);
+        }
+    }
+
     private static class TestItem {
 
+        @NonNull
         final static Uri CONTENT_URI = mock(Uri.class);
+
+        @NonNull
         final static String COLUMN_ID = "customIdColumnName";
+
         @Nullable
         private final Long id;
+
+        @NonNull
         static final Func1<TestItem, ContentValues> MAP_TO_CONTENT_VALUES = new Func1<TestItem, ContentValues>() {
 
             // ContentValues should be mocked for usage in tests (damn you Android...)

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/put/PutResultTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/put/PutResultTest.java
@@ -2,7 +2,15 @@ package com.pushtorefresh.storio.contentresolver.operations.put;
 
 import android.net.Uri;
 
+import com.pushtorefresh.storio.contentresolver.BuildConfig;
+import com.pushtorefresh.storio.test.ToStringChecker;
+
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -12,6 +20,8 @@ import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 import static org.mockito.Mockito.mock;
 
+@RunWith(RobolectricGradleTestRunner.class) // Required for correct Uri impl
+@Config(constants = BuildConfig.class, sdk = 21)
 public class PutResultTest {
 
     @Test
@@ -109,4 +119,19 @@ public class PutResultTest {
         }
     }
 
+    @Test
+    public void verifyEqualsAndHashCodeImplementation() {
+        EqualsVerifier
+                .forClass(PutResult.class)
+                .allFieldsShouldBeUsed()
+                .withPrefabValues(Uri.class, Uri.parse("content://1"), Uri.parse("content://2"))
+                .verify();
+    }
+
+    @Test
+    public void checkToStringImplementation() {
+        ToStringChecker
+                .forClass(PutResult.class)
+                .check();
+    }
 }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/put/PutResultsTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/operations/put/PutResultsTest.java
@@ -1,0 +1,87 @@
+package com.pushtorefresh.storio.contentresolver.operations.put;
+
+import android.net.Uri;
+
+import com.pushtorefresh.storio.contentresolver.BuildConfig;
+import com.pushtorefresh.storio.test.ToStringChecker;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricGradleTestRunner.class) // Required for correct Uri impl
+@Config(constants = BuildConfig.class, sdk = 21)
+public class PutResultsTest {
+
+    @Test
+    public void numberOfInsertsShouldBeZero() {
+        final Map<String, PutResult> putResultMap = singletonMap(
+                "key",
+                PutResult.newUpdateResult(1, Uri.parse("content://affectedUri"))
+        );
+
+        final PutResults<String> putResults = PutResults.newInstance(putResultMap);
+
+        assertEquals(0, putResults.numberOfInserts());
+
+        // We cache this value, so let's test that cache works too
+        // (coverage tool will report it as untested branch if we won't check this)
+        assertEquals(0, putResults.numberOfInserts());
+    }
+
+    @Test
+    public void numberOfUpdatesShouldBeZero() {
+        final Map<String, PutResult> putResultMap = new HashMap<String, PutResult>();
+        putResultMap.put("key", PutResult.newInsertResult(Uri.parse("content://insertedUri"), Uri.parse("content://affectedUri")));
+
+        final PutResults<String> putResults = PutResults.newInstance(putResultMap);
+
+        assertEquals(0, putResults.numberOfUpdates());
+
+        // We cache this value, so let's test that cache works too
+        // (coverage tool will report it as untested branch if we won't check this)
+        assertEquals(0, putResults.numberOfUpdates());
+    }
+
+    @Test
+    public void mixOfInsertsAndUpdatesShouldBeHandledCorrectly() {
+        final Map<String, PutResult> putResultMap = new HashMap<String, PutResult>();
+
+        // 3 inserts + 2 updates (notice, that one of the updates updated 5 rows!)
+
+        putResultMap.put("insert1", PutResult.newInsertResult(Uri.parse("content://insertedUri"), Uri.parse("content://affectedUri")));
+        putResultMap.put("update1", PutResult.newUpdateResult(5, Uri.parse("content://affectedUri")));
+        putResultMap.put("insert2", PutResult.newInsertResult(Uri.parse("content://insertedUri"), Uri.parse("content://affectedUri")));
+        putResultMap.put("update2", PutResult.newUpdateResult(1, Uri.parse("content://affectedUri")));
+        putResultMap.put("insert3", PutResult.newInsertResult(Uri.parse("content://insertedUri"), Uri.parse("content://affectedUri")));
+
+        final PutResults<String> putResults = PutResults.newInstance(putResultMap);
+
+        assertEquals(3, putResults.numberOfInserts());
+        assertEquals(6, putResults.numberOfUpdates());
+    }
+
+    @Test
+    public void verifyEqualsAndHashCodeImplementation() {
+        EqualsVerifier
+                .forClass(PutResults.class)
+                .allFieldsShouldBeUsed()
+                .verify();
+    }
+
+    @Test
+    public void checkToStringImplementation() {
+        ToStringChecker
+                .forClass(PutResults.class)
+                .check();
+    }
+}

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/queries/DeleteQueryTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/queries/DeleteQueryTest.java
@@ -2,28 +2,38 @@ package com.pushtorefresh.storio.contentresolver.queries;
 
 import android.net.Uri;
 
+import com.pushtorefresh.storio.contentresolver.BuildConfig;
+import com.pushtorefresh.storio.test.ToStringChecker;
+
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+@RunWith(RobolectricGradleTestRunner.class) // Required for correct Uri impl
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DeleteQueryTest {
 
-    @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullUriObject() {
+        //noinspection ConstantConditions
         DeleteQuery.builder()
                 .uri((Uri) null) // LOL, via overload we disabled null uri without specifying Type!
                 .build();
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class) // Uri#parse() not mocked
     public void shouldNotAllowNullUriString() {
+        //noinspection ConstantConditions
         DeleteQuery.builder()
                 .uri((String) null)
                 .build();
@@ -50,14 +60,6 @@ public class DeleteQueryTest {
         assertTrue(deleteQuery.whereArgs().isEmpty());
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void shouldThrowExceptionIfWhereArgsSpecifiedWithoutWhereClause() {
-        DeleteQuery.builder()
-                .uri(mock(Uri.class))
-                .whereArgs("someArg") // Without WHERE clause!
-                .build();
-    }
-
     @Test
     public void buildWithNormalValues() {
         final Uri uri = mock(Uri.class);
@@ -73,5 +75,21 @@ public class DeleteQueryTest {
         assertEquals(uri, deleteQuery.uri());
         assertEquals(where, deleteQuery.where());
         assertEquals(Arrays.asList(whereArgs), deleteQuery.whereArgs());
+    }
+
+    @Test
+    public void verifyEqualsAndHashCodeImplementation() {
+        EqualsVerifier
+                .forClass(DeleteQuery.class)
+                .allFieldsShouldBeUsed()
+                .withPrefabValues(Uri.class, Uri.parse("content://1"), Uri.parse("content://2"))
+                .verify();
+    }
+
+    @Test
+    public void checkToStringImplementation() {
+        ToStringChecker
+                .forClass(DeleteQuery.class)
+                .check();
     }
 }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/queries/InsertQueryTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/queries/InsertQueryTest.java
@@ -2,24 +2,34 @@ package com.pushtorefresh.storio.contentresolver.queries;
 
 import android.net.Uri;
 
+import com.pushtorefresh.storio.contentresolver.BuildConfig;
+import com.pushtorefresh.storio.test.ToStringChecker;
+
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
+@RunWith(RobolectricGradleTestRunner.class) // Required for correct Uri impl
+@Config(constants = BuildConfig.class, sdk = 21)
 public class InsertQueryTest {
 
-    @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullUriObject() {
+        //noinspection ConstantConditions
         InsertQuery.builder()
                 .uri((Uri) null)
                 .build();
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullUriString() {
+        //noinspection ConstantConditions
         InsertQuery.builder()
                 .uri((String) null)
                 .build();
@@ -34,5 +44,21 @@ public class InsertQueryTest {
                 .build();
 
         assertEquals(uri, insertQuery.uri());
+    }
+
+    @Test
+    public void verifyEqualsAndHashCodeImplementation() {
+        EqualsVerifier
+                .forClass(InsertQuery.class)
+                .allFieldsShouldBeUsed()
+                .withPrefabValues(Uri.class, Uri.parse("content://1"), Uri.parse("content://2"))
+                .verify();
+    }
+
+    @Test
+    public void checkToStringImplementation() {
+        ToStringChecker
+                .forClass(InsertQuery.class)
+                .check();
     }
 }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/queries/QueryTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/queries/QueryTest.java
@@ -2,7 +2,15 @@ package com.pushtorefresh.storio.contentresolver.queries;
 
 import android.net.Uri;
 
+import com.pushtorefresh.storio.contentresolver.BuildConfig;
+import com.pushtorefresh.storio.test.ToStringChecker;
+
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -10,19 +18,21 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+@RunWith(RobolectricGradleTestRunner.class) // Required for correct Uri impl
+@Config(constants = BuildConfig.class, sdk = 21)
 public class QueryTest {
 
-    @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullUriObject() {
+        //noinspection ConstantConditions
         Query.builder()
                 .uri((Uri) null)
                 .build();
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullUriString() {
+        //noinspection ConstantConditions
         Query.builder()
                 .uri((String) null)
                 .build();
@@ -89,5 +99,21 @@ public class QueryTest {
         assertEquals(where, query.where());
         assertEquals(asList(whereArgs), query.whereArgs());
         assertEquals(sortOrder, query.sortOrder());
+    }
+
+    @Test
+    public void verifyEqualsAndHashCodeImplementation() {
+        EqualsVerifier
+                .forClass(Query.class)
+                .allFieldsShouldBeUsed()
+                .withPrefabValues(Uri.class, Uri.parse("content://1"), Uri.parse("content://2"))
+                .verify();
+    }
+
+    @Test
+    public void checkToStringImplementation() {
+        ToStringChecker
+                .forClass(Query.class)
+                .check();
     }
 }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/queries/UpdateQueryTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/queries/UpdateQueryTest.java
@@ -2,7 +2,15 @@ package com.pushtorefresh.storio.contentresolver.queries;
 
 import android.net.Uri;
 
+import com.pushtorefresh.storio.contentresolver.BuildConfig;
+import com.pushtorefresh.storio.test.ToStringChecker;
+
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -10,19 +18,21 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+@RunWith(RobolectricGradleTestRunner.class) // Required for correct Uri impl
+@Config(constants = BuildConfig.class, sdk = 21)
 public class UpdateQueryTest {
 
-    @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullUriObject() {
+        //noinspection ConstantConditions
         UpdateQuery.builder()
                 .uri((Uri) null)
                 .build();
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullUriString() {
+        //noinspection ConstantConditions
         UpdateQuery.builder()
                 .uri((String) null)
                 .build();
@@ -48,14 +58,6 @@ public class UpdateQueryTest {
         assertTrue(updateQuery.whereArgs().isEmpty());
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void shouldThrowExceptionIfWhereArgsSpecifiedWithoutWhereClause() {
-        UpdateQuery.builder()
-                .uri(mock(Uri.class))
-                .whereArgs("someArg") // Without WHERE clause!
-                .build();
-    }
-
     @Test
     public void buildWithNormalValues() {
         final Uri uri = mock(Uri.class);
@@ -71,5 +73,21 @@ public class UpdateQueryTest {
         assertEquals(uri, updateQuery.uri());
         assertEquals(where, updateQuery.where());
         assertEquals(asList(whereArgs), updateQuery.whereArgs());
+    }
+
+    @Test
+    public void verifyEqualsAndHashCodeImplementation() {
+        EqualsVerifier
+                .forClass(UpdateQuery.class)
+                .allFieldsShouldBeUsed()
+                .withPrefabValues(Uri.class, Uri.parse("content://1"), Uri.parse("content://2"))
+                .verify();
+    }
+
+    @Test
+    public void checkToStringImplementation() {
+        ToStringChecker
+                .forClass(UpdateQuery.class)
+                .check();
     }
 }


### PR DESCRIPTION
Part of #450.

This PR adds more tests for StorIO-Content-Resolver and asserts that code coverage for this module at least 80%.

@nikitin-da PTAL