### PR TITLE
Ignore debug buildType for library projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,20 @@ allprojects {
     tasks.withType(JavaForkOptions) {
         jvmArgs '-Djava.awt.headless=true'
     }
+    
+    project.plugins.whenPluginAdded { plugin ->
+
+        // Ignore 'debug' buildType for library projects
+        // Because we don't have debug-specific code and we don't need to build debug variants
+        // https://gist.github.com/artem-zinnatullin/ec3bce6dcb2cd524c435
+        if ('com.android.build.gradle.LibraryPlugin'.equals(plugin.class.name)) {
+            project.android.variantFilter {
+                if (it.buildType.name.equals('debug')) {
+                    it.ignore = true
+                }
+            }
+        }
+    }
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
Should make our builds faster!

@nikitin-da PTAL