### PR TITLE
Fix possible deadlock caused by internal synchronization in SQLiteDatabase

### DIFF
--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/impl/DefaultStorIOSQLite.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/impl/DefaultStorIOSQLite.java
@@ -403,11 +403,11 @@ public class DefaultStorIOSQLite extends StorIOSQLite {
          */
         @Override
         public void beginTransaction() {
-            synchronized (lock) {
-                sqLiteOpenHelper
-                        .getWritableDatabase()
-                        .beginTransaction();
+            sqLiteOpenHelper
+                    .getWritableDatabase()
+                    .beginTransaction();
 
+            synchronized (lock) {
                 numberOfRunningTransactions++;
             }
         }
@@ -417,11 +417,10 @@ public class DefaultStorIOSQLite extends StorIOSQLite {
          */
         @Override
         public void setTransactionSuccessful() {
-            synchronized (lock) {
-                sqLiteOpenHelper
-                        .getWritableDatabase()
-                        .setTransactionSuccessful();
-            }
+            // SQLiteDatabase has it's own synchronization
+            sqLiteOpenHelper
+                    .getWritableDatabase()
+                    .setTransactionSuccessful();
         }
 
         /**
@@ -429,11 +428,12 @@ public class DefaultStorIOSQLite extends StorIOSQLite {
          */
         @Override
         public void endTransaction() {
-            synchronized (lock) {
-                sqLiteOpenHelper
-                        .getWritableDatabase()
-                        .endTransaction();
+            // SQLiteDatabase has it's own synchronization
+            sqLiteOpenHelper
+                    .getWritableDatabase()
+                    .endTransaction();
 
+            synchronized (lock) {
                 numberOfRunningTransactions--;
                 notifyAboutPendingChangesIfNotInTransaction();
             }

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/put/PreparedPutContentValuesIterable.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/put/PreparedPutContentValuesIterable.java
@@ -91,6 +91,8 @@ public final class PreparedPutContentValuesIterable extends PreparedPut<PutResul
                             affectedTables.addAll(putResults.get(contentValues).affectedTables());
                         }
 
+                        // IMPORTANT: Notifying about change should be done after end of transaction
+                        // It'll reduce number of possible deadlock situations
                         internal.notifyAboutChanges(Changes.newInstance(affectedTables));
                     }
                 }


### PR DESCRIPTION
Relolves #481.

At the moment, `StorIOSQLite` Operations already written in such way that they send notifications after transaction, so I just moved calls to `SQLiteDatabase` transactions out of the synchronization and keep code that manages notifications as is. 

@nikitin-da and @tadas-subonis please take a look and comment!

#deadlocksgoaway