### PR TITLE
Add public Queries utils with function for generating placeholders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ ext.libraries = [
 
         // Libraries for tests and sample app
         junit                          : 'junit:junit:4.12',
+        assertJ                        : 'org.assertj:assertj-core:1.7.1',
         mockitoCore                    : 'org.mockito:mockito-core:1.10.19',
         powerMockJUnit                 : 'org.powermock:powermock-module-junit4:1.6.2',
         powerMockMockito               : 'org.powermock:powermock-api-mockito:1.6.2',

--- a/storio-common/build.gradle
+++ b/storio-common/build.gradle
@@ -17,6 +17,10 @@ android {
     packagingOptions {
         exclude 'LICENSE.txt' // multiple libs have this file -> cause build error
     }
+
+    lintOptions {
+        disable 'InvalidPackage' // AssertJ references java.nio package, which is not available on Android
+    }
 }
 
 dependencies {
@@ -24,6 +28,7 @@ dependencies {
     provided libraries.rxJava
 
     testCompile libraries.junit
+    testCompile libraries.assertJ
     testCompile libraries.mockitoCore
     testCompile libraries.powerMockJUnit
     testCompile libraries.powerMockMockito

--- a/storio-common/src/main/java/com/pushtorefresh/storio/Queries.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio/Queries.java
@@ -1,0 +1,43 @@
+package com.pushtorefresh.storio;
+
+import android.support.annotation.NonNull;
+
+/**
+ * Public collection of util methods for Queries.
+ */
+public class Queries {
+
+    private Queries() {
+        // No instances.
+    }
+
+    /**
+     * Generates required number of placeholders as string.
+     *
+     * Example: {@code numberOfPlaceholders == 1, result == "?"},
+     * {@code numberOfPlaceholders == 2, result == "?,?"}.
+     *
+     * @param numberOfPlaceholders required amount of placeholders, should be {@code > 0}.
+     * @return string with placeholders.
+     */
+    @NonNull
+    public static String placeholders(final int numberOfPlaceholders) {
+        if (numberOfPlaceholders == 1) {
+            return "?"; // fffast
+        } else if (numberOfPlaceholders <= 0) {
+            throw new IllegalArgumentException("numberOfPlaceholders must be > 0, but was = " + numberOfPlaceholders);
+        }
+
+        final StringBuilder stringBuilder = new StringBuilder((numberOfPlaceholders * 2) - 1);
+
+        for (int i = 0; i < numberOfPlaceholders; i++) {
+            stringBuilder.append('?');
+
+            if (i != numberOfPlaceholders - 1) {
+                stringBuilder.append(',');
+            }
+        }
+
+        return stringBuilder.toString();
+    }
+}

--- a/storio-common/src/main/java/com/pushtorefresh/storio/internal/InternalQueries.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio/internal/InternalQueries.java
@@ -17,9 +17,9 @@ import static java.util.Collections.unmodifiableList;
  * <p>
  * For internal usage only!
  */
-public final class Queries {
+public final class InternalQueries {
 
-    private Queries() {
+    private InternalQueries() {
         throw new IllegalStateException("No instances please");
     }
 

--- a/storio-common/src/test/java/com/pushtorefresh/storio/QueriesTest.java
+++ b/storio-common/src/test/java/com/pushtorefresh/storio/QueriesTest.java
@@ -1,0 +1,53 @@
+package com.pushtorefresh.storio;
+
+import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class QueriesTest {
+
+    @Test
+    public void constructorShouldBePrivate() {
+        PrivateConstructorChecker
+                .forClass(Queries.class)
+                .check();
+    }
+
+    @Test
+    public void placeholdersMinus1() {
+        try {
+            Queries.placeholders(-1);
+            fail("Should throw exception");
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessage("numberOfPlaceholders must be > 0, but was = -1");
+        }
+    }
+
+    @Test
+    public void placeholders0() {
+        try {
+            Queries.placeholders(0);
+            fail("Should throw exception");
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessage("numberOfPlaceholders must be > 0, but was = 0");
+        }
+    }
+
+    @Test
+    public void placeholders1() {
+        assertThat(Queries.placeholders(1)).isEqualTo("?");
+    }
+
+    @Test
+    public void placeholders2() {
+        assertThat(Queries.placeholders(2)).isEqualTo("?,?");
+    }
+
+    @Test
+    public void placeholders3() {
+        assertThat(Queries.placeholders(3)).isEqualTo("?,?,?");
+    }
+}

--- a/storio-common/src/test/java/com/pushtorefresh/storio/internal/InternalQueriesTest.java
+++ b/storio-common/src/test/java/com/pushtorefresh/storio/internal/InternalQueriesTest.java
@@ -18,12 +18,12 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 
-public class QueriesTest {
+public class InternalQueriesTest {
 
     @Test
     public void constructorShouldBePrivateAndThrowException() {
         PrivateConstructorChecker
-                .forClass(Queries.class)
+                .forClass(InternalQueries.class)
                 .expectedTypeOfException(IllegalStateException.class)
                 .expectedExceptionMessage("No instances please")
                 .check();
@@ -35,19 +35,19 @@ public class QueriesTest {
     @Test
     public void nullArrayToUnmodifiableNonNullListOfStrings() {
         Object[] array = null;
-        assertEquals(emptyList(), Queries.unmodifiableNonNullListOfStrings(array));
+        assertEquals(emptyList(), InternalQueries.unmodifiableNonNullListOfStrings(array));
     }
 
     @Test
     public void emptyArrayToUnmodifiableNonNullListOfStrings() {
         Object[] array = {};
-        assertEquals(emptyList(), Queries.unmodifiableNonNullListOfStrings(array));
+        assertEquals(emptyList(), InternalQueries.unmodifiableNonNullListOfStrings(array));
     }
 
     @Test
     public void nonEmptyArrayToUnmodifiableNonNullListOfStrings() {
         Object[] array = {"1", "2", "3"};
-        List<String> list = Queries.unmodifiableNonNullListOfStrings(array);
+        List<String> list = InternalQueries.unmodifiableNonNullListOfStrings(array);
 
         assertEquals(array.length, list.size());
 
@@ -59,7 +59,7 @@ public class QueriesTest {
     @Test
     public void nullItemInArrayToUnmodifiableNonNullListOfStrings() {
         Object[] array = {"1", null, "3"};
-        List<String> strings = Queries.unmodifiableNonNullListOfStrings(array);
+        List<String> strings = InternalQueries.unmodifiableNonNullListOfStrings(array);
 
         assertEquals("1", strings.get(0));
         assertEquals("null", strings.get(1));
@@ -74,25 +74,25 @@ public class QueriesTest {
     @Test
     public void nullListToUnmodifiableNonNullListOfStrings() {
         List<Object> list = null;
-        assertEquals(emptyList(), Queries.unmodifiableNonNullListOfStrings(list));
+        assertEquals(emptyList(), InternalQueries.unmodifiableNonNullListOfStrings(list));
     }
 
     @Test
     public void emptyListToUnmodifiableNonNullListOfStrings() {
         List<Object> list = new ArrayList<Object>();
-        assertEquals(emptyList(), Queries.unmodifiableNonNullListOfStrings(list));
+        assertEquals(emptyList(), InternalQueries.unmodifiableNonNullListOfStrings(list));
     }
 
     @Test
     public void nonEmptyListToUnmodifiableNonNullListOfStrings() {
         List<String> strings = asList("1", "2", "3");
-        assertEquals(strings, Queries.unmodifiableNonNullListOfStrings(strings));
+        assertEquals(strings, InternalQueries.unmodifiableNonNullListOfStrings(strings));
     }
 
     @Test
     public void nonEmptyListWithNullElementToUnmodifiableNonNullListOfStrings() {
         List<String> strings = asList("1", null, "3");
-        List<String> result = Queries.unmodifiableNonNullListOfStrings(strings);
+        List<String> result = InternalQueries.unmodifiableNonNullListOfStrings(strings);
 
         assertEquals("1", result.get(0));
         assertEquals("null", result.get(1));
@@ -108,19 +108,19 @@ public class QueriesTest {
     @Test
     public void nullListToUnmodifiableNonNullList() {
         List<String> list = null;
-        assertEquals(emptyList(), Queries.unmodifiableNonNullList(list));
+        assertEquals(emptyList(), InternalQueries.unmodifiableNonNullList(list));
     }
 
     @Test
     public void emptyListToUnmodifiableNonNullList() {
         List<String> list = new ArrayList<String>();
-        assertEquals(emptyList(), Queries.unmodifiableNonNullList(list));
+        assertEquals(emptyList(), InternalQueries.unmodifiableNonNullList(list));
     }
 
     @Test
     public void nonEmptyListToUnmodifiableNonNullList() {
         List<String> list = asList("1", "2", "3");
-        List<String> unmodifiableList = Queries.unmodifiableNonNullList(list);
+        List<String> unmodifiableList = InternalQueries.unmodifiableNonNullList(list);
 
         assertEquals(list.size(), unmodifiableList.size());
 
@@ -132,7 +132,7 @@ public class QueriesTest {
 
     @Test
     public void listToUnmodifiableNonNullListIsReallyUnmodifiable() {
-        List<String> unmodifiableList = Queries.unmodifiableNonNullList(asList("1", "2", "3"));
+        List<String> unmodifiableList = InternalQueries.unmodifiableNonNullList(asList("1", "2", "3"));
         assertThatListIsImmutable(unmodifiableList);
     }
 
@@ -142,12 +142,12 @@ public class QueriesTest {
 
     @Test
     public void nullSetToUnmodifiableNonNullSet() {
-        assertEquals(emptySet(), Queries.unmodifiableNonNullSet(null));
+        assertEquals(emptySet(), InternalQueries.unmodifiableNonNullSet(null));
     }
 
     @Test
     public void emptySetToUnmodifiableNonNullSet() {
-        assertEquals(emptySet(), Queries.unmodifiableNonNullSet(new HashSet<Object>()));
+        assertEquals(emptySet(), InternalQueries.unmodifiableNonNullSet(new HashSet<Object>()));
     }
 
     @Test
@@ -158,7 +158,7 @@ public class QueriesTest {
         testSet.add("2");
         testSet.add("3");
 
-        Set<String> unmodifiableSet = Queries.unmodifiableNonNullSet(testSet);
+        Set<String> unmodifiableSet = InternalQueries.unmodifiableNonNullSet(testSet);
 
         assertEquals(testSet, unmodifiableSet);
     }
@@ -171,19 +171,19 @@ public class QueriesTest {
     @Test
     public void nullListOfStringsToNonNullArrayOfStrings() {
         List<String> list = null;
-        assertTrue(Arrays.equals(new String[]{}, Queries.nonNullArrayOfStrings(list)));
+        assertTrue(Arrays.equals(new String[]{}, InternalQueries.nonNullArrayOfStrings(list)));
     }
 
     @Test
     public void emptyListOfStringsToNonNullArrayOfStrings() {
         List<String> list = new ArrayList<String>();
-        assertTrue(Arrays.equals(new String[]{}, Queries.nonNullArrayOfStrings(list)));
+        assertTrue(Arrays.equals(new String[]{}, InternalQueries.nonNullArrayOfStrings(list)));
     }
 
     @Test
     public void nonEmptyListOfStringsToNonNullArrayOfStrings() {
         List<String> list = asList("1", "2", "3");
-        String[] array = Queries.nonNullArrayOfStrings(list);
+        String[] array = InternalQueries.nonNullArrayOfStrings(list);
 
         assertEquals(list.size(), array.length);
 
@@ -198,19 +198,19 @@ public class QueriesTest {
 
     @Test
     public void nullListOfStringsToNullableArrayOfString() {
-        assertEquals(null, Queries.nullableArrayOfStrings(null));
+        assertEquals(null, InternalQueries.nullableArrayOfStrings(null));
     }
 
     @Test
     public void emptyListOfStringsToNullableArrayOfString() {
         List<String> list = new ArrayList<String>();
-        assertEquals(null, Queries.nullableArrayOfStrings(list));
+        assertEquals(null, InternalQueries.nullableArrayOfStrings(list));
     }
 
     @Test
     public void nonEmptyListOfStringsToNullableArrayOfStrings() {
         List<String> list = asList("1", "2", "3");
-        String[] array = Queries.nullableArrayOfStrings(list);
+        String[] array = InternalQueries.nullableArrayOfStrings(list);
 
         assertNotNull(array);
         assertEquals(list.size(), array.length);
@@ -226,17 +226,17 @@ public class QueriesTest {
 
     @Test
     public void nonNullStringFromNull() {
-        assertEquals("", Queries.nonNullString(null));
+        assertEquals("", InternalQueries.nonNullString(null));
     }
 
     @Test
     public void nonNullStringFromEmptyString() {
-        assertEquals("", Queries.nonNullString(""));
+        assertEquals("", InternalQueries.nonNullString(""));
     }
 
     @Test
     public void nonNullStringFromNormalString() {
-        assertEquals("123", Queries.nonNullString("123"));
+        assertEquals("123", InternalQueries.nonNullString("123"));
     }
 
     //endregion
@@ -245,17 +245,17 @@ public class QueriesTest {
 
     @Test
     public void nullableStringFromNull() {
-        assertEquals(null, Queries.nullableString(null));
+        assertEquals(null, InternalQueries.nullableString(null));
     }
 
     @Test
     public void nullableStringFromEmptyString() {
-        assertEquals(null, Queries.nullableString(""));
+        assertEquals(null, InternalQueries.nullableString(""));
     }
 
     @Test
     public void nullableStringFromNormalString() {
-        assertEquals("123", Queries.nullableString("123"));
+        assertEquals("123", InternalQueries.nullableString("123"));
     }
 
     //endregion

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/impl/DefaultStorIOContentResolver.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/impl/DefaultStorIOContentResolver.java
@@ -28,8 +28,8 @@ import rx.Observable;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 import static com.pushtorefresh.storio.internal.Environment.throwExceptionIfRxJavaIsNotAvailable;
-import static com.pushtorefresh.storio.internal.Queries.nullableArrayOfStrings;
-import static com.pushtorefresh.storio.internal.Queries.nullableString;
+import static com.pushtorefresh.storio.internal.InternalQueries.nullableArrayOfStrings;
+import static com.pushtorefresh.storio.internal.InternalQueries.nullableString;
 import static java.util.Collections.unmodifiableMap;
 
 /**

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/DefaultPutResolver.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/put/DefaultPutResolver.java
@@ -10,8 +10,8 @@ import com.pushtorefresh.storio.contentresolver.queries.InsertQuery;
 import com.pushtorefresh.storio.contentresolver.queries.Query;
 import com.pushtorefresh.storio.contentresolver.queries.UpdateQuery;
 
-import static com.pushtorefresh.storio.internal.Queries.nullableArrayOfStrings;
-import static com.pushtorefresh.storio.internal.Queries.nullableString;
+import static com.pushtorefresh.storio.internal.InternalQueries.nullableArrayOfStrings;
+import static com.pushtorefresh.storio.internal.InternalQueries.nullableString;
 
 /**
  * Default thread-safe implementation of {@link PutResolver}.

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/DeleteQuery.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/DeleteQuery.java
@@ -7,9 +7,9 @@ import android.support.annotation.Nullable;
 import java.util.List;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
-import static com.pushtorefresh.storio.internal.Queries.nonNullString;
-import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullList;
-import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullListOfStrings;
+import static com.pushtorefresh.storio.internal.InternalQueries.nonNullString;
+import static com.pushtorefresh.storio.internal.InternalQueries.unmodifiableNonNullList;
+import static com.pushtorefresh.storio.internal.InternalQueries.unmodifiableNonNullListOfStrings;
 
 /**
  * Delete query for {@link com.pushtorefresh.storio.contentresolver.StorIOContentResolver}.

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/Query.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/Query.java
@@ -7,9 +7,9 @@ import android.support.annotation.Nullable;
 import java.util.List;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
-import static com.pushtorefresh.storio.internal.Queries.nonNullString;
-import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullList;
-import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullListOfStrings;
+import static com.pushtorefresh.storio.internal.InternalQueries.nonNullString;
+import static com.pushtorefresh.storio.internal.InternalQueries.unmodifiableNonNullList;
+import static com.pushtorefresh.storio.internal.InternalQueries.unmodifiableNonNullListOfStrings;
 
 /**
  * Query for {@link com.pushtorefresh.storio.contentresolver.StorIOContentResolver}.

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/UpdateQuery.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/queries/UpdateQuery.java
@@ -7,9 +7,9 @@ import android.support.annotation.Nullable;
 import java.util.List;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
-import static com.pushtorefresh.storio.internal.Queries.nonNullString;
-import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullList;
-import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullListOfStrings;
+import static com.pushtorefresh.storio.internal.InternalQueries.nonNullString;
+import static com.pushtorefresh.storio.internal.InternalQueries.unmodifiableNonNullList;
+import static com.pushtorefresh.storio.internal.InternalQueries.unmodifiableNonNullListOfStrings;
 
 /**
  * Update query for {@link com.pushtorefresh.storio.contentresolver.StorIOContentResolver}.

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/impl/DefaultStorIOSQLite.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/impl/DefaultStorIOSQLite.java
@@ -29,8 +29,8 @@ import rx.Observable;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotNull;
 import static com.pushtorefresh.storio.internal.Environment.RX_JAVA_IS_IN_THE_CLASS_PATH;
-import static com.pushtorefresh.storio.internal.Queries.nullableArrayOfStrings;
-import static com.pushtorefresh.storio.internal.Queries.nullableString;
+import static com.pushtorefresh.storio.internal.InternalQueries.nullableArrayOfStrings;
+import static com.pushtorefresh.storio.internal.InternalQueries.nullableString;
 import static java.util.Collections.unmodifiableMap;
 
 /**

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/put/DefaultPutResolver.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/put/DefaultPutResolver.java
@@ -9,8 +9,8 @@ import com.pushtorefresh.storio.sqlite.queries.InsertQuery;
 import com.pushtorefresh.storio.sqlite.queries.Query;
 import com.pushtorefresh.storio.sqlite.queries.UpdateQuery;
 
-import static com.pushtorefresh.storio.internal.Queries.nullableArrayOfStrings;
-import static com.pushtorefresh.storio.internal.Queries.nullableString;
+import static com.pushtorefresh.storio.internal.InternalQueries.nullableArrayOfStrings;
+import static com.pushtorefresh.storio.internal.InternalQueries.nullableString;
 
 /**
  * Default implementation of {@link PutResolver}.

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/DeleteQuery.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/DeleteQuery.java
@@ -6,8 +6,8 @@ import android.support.annotation.Nullable;
 import java.util.List;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotEmpty;
-import static com.pushtorefresh.storio.internal.Queries.nonNullString;
-import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullListOfStrings;
+import static com.pushtorefresh.storio.internal.InternalQueries.nonNullString;
+import static com.pushtorefresh.storio.internal.InternalQueries.unmodifiableNonNullListOfStrings;
 
 /**
  * Delete query for {@link com.pushtorefresh.storio.sqlite.StorIOSQLite}.

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/Query.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/Query.java
@@ -6,8 +6,8 @@ import android.support.annotation.Nullable;
 import java.util.List;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotEmpty;
-import static com.pushtorefresh.storio.internal.Queries.nonNullString;
-import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullListOfStrings;
+import static com.pushtorefresh.storio.internal.InternalQueries.nonNullString;
+import static com.pushtorefresh.storio.internal.InternalQueries.unmodifiableNonNullListOfStrings;
 
 /**
  * Get query for {@link com.pushtorefresh.storio.sqlite.StorIOSQLite}.

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/RawQuery.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/RawQuery.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.Set;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotEmpty;
-import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullListOfStrings;
-import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullSet;
+import static com.pushtorefresh.storio.internal.InternalQueries.unmodifiableNonNullListOfStrings;
+import static com.pushtorefresh.storio.internal.InternalQueries.unmodifiableNonNullSet;
 
 /**
  * Raw SQL query for {@link com.pushtorefresh.storio.sqlite.StorIOSQLite}.

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/UpdateQuery.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/queries/UpdateQuery.java
@@ -6,8 +6,8 @@ import android.support.annotation.Nullable;
 import java.util.List;
 
 import static com.pushtorefresh.storio.internal.Checks.checkNotEmpty;
-import static com.pushtorefresh.storio.internal.Queries.nonNullString;
-import static com.pushtorefresh.storio.internal.Queries.unmodifiableNonNullListOfStrings;
+import static com.pushtorefresh.storio.internal.InternalQueries.nonNullString;
+import static com.pushtorefresh.storio.internal.InternalQueries.unmodifiableNonNullListOfStrings;
 
 /**
  * Update query for {@link com.pushtorefresh.storio.sqlite.StorIOSQLite}.


### PR DESCRIPTION
And rename internal `Queries` -> `InternalQueries`.

Closes #474!

@nikitin-da PTAL!

Also, I've added AssertJ, see #484.