### PR TITLE
Remove unnecessary synchronization, prevent possible deadlocks, faster & better

### DIFF
--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/impl/DefaultStorIOSQLiteTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/impl/DefaultStorIOSQLiteTest.java
@@ -280,7 +280,7 @@ public class DefaultStorIOSQLiteTest {
 
     // See https://github.com/pushtorefresh/storio/issues/478
     @Test
-    public void nestedTransactionShouldWorkOkay() {
+    public void nestedTransactionShouldWorkNormally() {
         SQLiteOpenHelper sqLiteOpenHelper = mock(SQLiteOpenHelper.class);
         SQLiteDatabase sqLiteDatabase = mock(SQLiteDatabase.class);
 

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/integration/RxQueryTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/integration/RxQueryTest.java
@@ -3,6 +3,7 @@ package com.pushtorefresh.storio.sqlite.integration;
 import android.support.annotation.NonNull;
 
 import com.pushtorefresh.storio.sqlite.BuildConfig;
+import com.pushtorefresh.storio.sqlite.Changes;
 import com.pushtorefresh.storio.test.AbstractEmissionChecker;
 
 import org.junit.Test;
@@ -14,9 +15,13 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
 
 import rx.Subscription;
 import rx.functions.Action1;
+import rx.observers.TestSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21)
@@ -139,5 +144,59 @@ public class RxQueryTest extends BaseTest {
         emissionChecker.assertThatNoExpectedValuesLeft();
 
         subscription.unsubscribe();
+    }
+
+    @Test
+    public void parallelWritesWithoutTransaction() {
+        final int numberOfParallelWorkers = 50;
+
+        TestSubscriber<Changes> testSubscriber = new TestSubscriber<Changes>();
+
+        storIOSQLite
+                .observeChangesInTable(TweetTableMeta.TABLE)
+                .take(numberOfParallelWorkers)
+                .subscribe(testSubscriber);
+
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+        for (int i = 0; i < numberOfParallelWorkers; i++) {
+            final int copyOfCurrentI = i;
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        countDownLatch.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    storIOSQLite
+                            .put()
+                            .object(Tweet.newInstance(null, 1L, "Some text: " + copyOfCurrentI))
+                            .prepare()
+                            .executeAsBlocking();
+                }
+            }).start();
+        }
+
+        // Release the KRAKEN!
+        countDownLatch.countDown();
+
+        testSubscriber.awaitTerminalEvent();
+        testSubscriber.assertNoErrors();
+        assertThat(testSubscriber.getOnNextEvents()).hasSize(numberOfParallelWorkers);
+    }
+
+    @Test
+    public void nestedTransaction() {
+        storIOSQLite.internal().beginTransaction();
+
+        storIOSQLite.internal().beginTransaction();
+
+        storIOSQLite.internal().setTransactionSuccessful();
+        storIOSQLite.internal().endTransaction();
+
+        storIOSQLite.internal().setTransactionSuccessful();
+        storIOSQLite.internal().endTransaction();
     }
 }


### PR DESCRIPTION
Problem: we send notification to the `changesBus` inside of `synchronized(lock)` block and this notification may invoke user code that may open a db transaction and then wait for the `synchronized(lock)` and because of this db transaction, lock may never be released.

This PR fixes possible deadlock via moving notifications out of the `synchronized(lock)` block and also makes internal implementation faster.

@nikitin-da PTAL!