### PR TITLE
Add getter for underlying ContentResolver to the StorIOContentResolver

### DIFF
--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/StorIOContentResolver.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/StorIOContentResolver.java
@@ -1,5 +1,6 @@
 package com.pushtorefresh.storio.contentresolver;
 
+import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
@@ -152,5 +153,14 @@ public abstract class StorIOContentResolver {
          */
         @WorkerThread
         public abstract int delete(@NonNull DeleteQuery deleteQuery);
+
+        /**
+         * Returns {@link ContentResolver} that can be used for operations
+         * like {@link ContentResolver#applyBatch(String, java.util.ArrayList)} and so on!
+         *
+         * @return {@link ContentResolver}.
+         */
+        @NonNull
+        public abstract ContentResolver contentResolver();
     }
 }

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/impl/DefaultStorIOContentResolver.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/impl/DefaultStorIOContentResolver.java
@@ -325,5 +325,14 @@ public class DefaultStorIOContentResolver extends StorIOContentResolver {
                     nullableArrayOfStrings(deleteQuery.whereArgs())
             );
         }
+
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public ContentResolver contentResolver() {
+            return contentResolver;
+        }
     }
 }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/design/DesignTestStorIOContentResolver.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/design/DesignTestStorIOContentResolver.java
@@ -1,5 +1,6 @@
 package com.pushtorefresh.storio.contentresolver.design;
 
+import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
@@ -68,6 +69,13 @@ class DesignTestStorIOContentResolver extends StorIOContentResolver {
         public int delete(@NonNull DeleteQuery deleteQuery) {
             // no impl
             return 0;
+        }
+
+        @NonNull
+        @Override
+        public ContentResolver contentResolver() {
+            // no impl
+            return null;
         }
     }
 }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/impl/DefaultStorIOContentResolverTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/impl/DefaultStorIOContentResolverTest.java
@@ -287,4 +287,15 @@ public class DefaultStorIOContentResolverTest {
             assertThat(expected).hasMessage("Cursor returned by content provider is null");
         }
     }
+
+    @Test
+    public void shouldReturnSameContentResolver() {
+        ContentResolver contentResolver = mock(ContentResolver.class);
+
+        StorIOContentResolver storIOContentResolver = DefaultStorIOContentResolver.builder()
+                .contentResolver(contentResolver)
+                .build();
+
+        assertThat(storIOContentResolver.internal().contentResolver()).isSameAs(contentResolver);
+    }
 }


### PR DESCRIPTION
Closes #284.

Since we don't need track changes of the `ContentProvider` manually like we do for `StorIOSQLite` I just added a getter for the `ContentResolver` so users can use it in their Operation Resolvers!

@nikitin-da PTAL :)