### PR TITLE
Handle backpressure for Get Operation via RxJava

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ def daggerVersion = '2.0.1'
 ext.libraries = [
         // Core libraries
         supportAnnotations             : 'com.android.support:support-annotations:' + supportLibsVersion,
-        rxJava                         : 'io.reactivex:rxjava:1.0.15',
+        rxJava                         : 'io.reactivex:rxjava:1.1.0',
 
         // Parts of StorIO
         storIOCommon                              : project(':storio-common'),

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetCursor.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetCursor.java
@@ -82,6 +82,7 @@ public final class PreparedGetCursor extends PreparedGet<Cursor> {
                 .observeChangesOfUri(query.uri()) // each change triggers executeAsBlocking
                 .map(MapSomethingToExecuteAsBlocking.newInstance(this))
                 .startWith(Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this))) // start stream with first query result
+                .onBackpressureLatest()
                 .subscribeOn(Schedulers.io());
     }
 

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetListOfObjects.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetListOfObjects.java
@@ -132,6 +132,7 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<List<T>> {
                 .observeChangesOfUri(query.uri()) // each change triggers executeAsBlocking
                 .map(MapSomethingToExecuteAsBlocking.newInstance(this))
                 .startWith(Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this))) // start stream with first query result
+                .onBackpressureLatest()
                 .subscribeOn(Schedulers.io());
     }
 

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetNumberOfResults.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetNumberOfResults.java
@@ -81,6 +81,7 @@ public class PreparedGetNumberOfResults extends PreparedGet<Integer> {
                 .observeChangesOfUri(query.uri()) // each change triggers executeAsBlocking
                 .map(MapSomethingToExecuteAsBlocking.newInstance(this))
                 .startWith(Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this))) // start stream with first query result
+                .onBackpressureLatest()
                 .subscribeOn(Schedulers.io());
     }
 

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetObject.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio/contentresolver/operations/get/PreparedGetObject.java
@@ -123,6 +123,7 @@ public final class PreparedGetObject<T> extends PreparedGet<T> {
                 .observeChangesOfUri(query.uri()) // each change triggers executeAsBlocking
                 .map(MapSomethingToExecuteAsBlocking.newInstance(this))
                 .startWith(Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this))) // start stream with first query result
+                .onBackpressureLatest()
                 .subscribeOn(Schedulers.io());
     }
 

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/get/PreparedGetCursor.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/get/PreparedGetCursor.java
@@ -109,6 +109,7 @@ public final class PreparedGetCursor extends PreparedGet<Cursor> {
                     .observeChangesInTables(tables) // each change triggers executeAsBlocking
                     .map(MapSomethingToExecuteAsBlocking.newInstance(this))
                     .startWith(Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this))) // start stream with first query result
+                    .onBackpressureLatest()
                     .subscribeOn(Schedulers.io());
         } else {
             return Observable

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/get/PreparedGetListOfObjects.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/get/PreparedGetListOfObjects.java
@@ -162,6 +162,7 @@ public final class PreparedGetListOfObjects<T> extends PreparedGet<List<T>> {
                     .observeChangesInTables(tables) // each change triggers executeAsBlocking
                     .map(MapSomethingToExecuteAsBlocking.newInstance(this))
                     .startWith(Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this))) // start stream with first query result
+                    .onBackpressureLatest()
                     .subscribeOn(Schedulers.io());
         } else {
             return Observable

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/get/PreparedGetNumberOfResults.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/get/PreparedGetNumberOfResults.java
@@ -109,6 +109,7 @@ public final class PreparedGetNumberOfResults extends PreparedGet<Integer> {
                     .observeChangesInTables(tables) // each change triggers executeAsBlocking
                     .map(MapSomethingToExecuteAsBlocking.newInstance(this))
                     .startWith(Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this))) // start stream with first query result
+                    .onBackpressureLatest()
                     .subscribeOn(Schedulers.io());
         } else {
             return Observable

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/get/PreparedGetObject.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio/sqlite/operations/get/PreparedGetObject.java
@@ -147,6 +147,7 @@ public class PreparedGetObject<T> extends PreparedGet<T> {
                     .observeChangesInTables(tables) // each change triggers executeAsBlocking
                     .map(MapSomethingToExecuteAsBlocking.newInstance(this))
                     .startWith(Observable.create(OnSubscribeExecuteAsBlocking.newInstance(this))) // start stream with first query result
+                    .onBackpressureLatest()
                     .subscribeOn(Schedulers.io());
         } else {
             return Observable


### PR DESCRIPTION
Closes #559.

Finally, RxJava 1.1.0 contains required operator to keep consistency for Get Operation and handle backpressure at the same time!

@nikitin-da PTAL!