### PR TITLE
Unit tests for storio-common-annotations-processor module to increase code coverage from 29% to 96%

### DIFF
--- a/CODE_COVERAGE.md
+++ b/CODE_COVERAGE.md
@@ -1,0 +1,44 @@
+# Code Coverage Report generation
+
+# For Android Modules
+
+Here are some of the andriod modules:
+* storio-common
+* storio-content-resolver
+* storio-sample-app
+* storio-sqlite
+* storio-test-common
+* storio-test-without-rxjava
+
+To generate the code coverage report for android modules, execute the following command:
+
+> Windows: ci.sh
+> Linux/Unix/ OSX: ./ci.sh
+
+This will generate code coverage report in each of the modules. In order to view the same, open the following file in your browser.
+> ROOT/MODULE_NAME/build/reports/jacoco
+
+Please note that the above folder is created under each of the modules. For example:
+* pushtorefresh-storio/storio-common/build/reports/jacoco/testReleaseUnitTestCoverage/html/index.html
+* pushtorefresh-storio/storio-content-resolver/build/reports/jacoco/testReleaseUnitTestCoverage/html/index.html
+
+# For Non-Android Modules
+
+Here are some of the non-andriod modules:
+* storio-common-annotations-processor
+* storio-content-resolver-annotations
+* storio-content-resolver-annotations-processor
+* storio-sqlite-annotations
+* storio-sqlite-annotations-processor
+
+To generate the coverage report for non-android modules, execute the following commands at the module's root directory:
+
+> Windows: gradle jacocoTestReport
+> Linux/Unix/ OSX: ./gradle jacocoTestReport
+
+This will generate code coverage report in each of the modules. In order to view the same, open the following file in your browser.
+> ROOT/MODULE_NAME/build/reports/jacoco
+
+Please note that the above folder is created under each of the modules. For example:
+* pushtorefresh-storio/storio-common-annotations-processor/build/reports/jacoco/test/index.html
+* pushtorefresh-storio/storio-content-resolver-annotations/build/reports/jacoco/testReleaseUnitTestCoverage/html/index.html

--- a/gradle/jacoco-non-android.gradle
+++ b/gradle/jacoco-non-android.gradle
@@ -1,0 +1,15 @@
+apply plugin: 'jacoco'
+
+jacoco {
+    // See https://github.com/jacoco/jacoco/releases
+    toolVersion = '0.7.5.201505241946'
+    reportsDir = file("$buildDir/customJacocoReportDir")
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        csv.enabled true
+        html.destination "${buildDir}/reports/jacoco/test"
+    }
+}

--- a/storio-common-annotations-processor/build.gradle
+++ b/storio-common-annotations-processor/build.gradle
@@ -11,6 +11,10 @@ dependencies {
     testCompile libraries.junit
     testCompile libraries.assertJ
     testCompile libraries.mockitoCore
+    testCompile libraries.powerMockJUnit
+    testCompile libraries.powerMockMockito
+    testCompile libraries.equalsVerifier
 }
 
 apply from: '../gradle/publish-java-lib.gradle'
+apply from: '../gradle/jacoco-non-android.gradle'

--- a/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/ProcessingExceptionTest.java
+++ b/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/ProcessingExceptionTest.java
@@ -1,0 +1,40 @@
+package com.pushtorefresh.storio.common.annotations.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.reflect.Whitebox.getInternalState;
+
+import javax.lang.model.element.Element;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ProcessingExceptionTest {
+
+	private Element elementMock;
+
+	@Before
+	public void setUp() throws Exception {
+		elementMock = mock(Element.class);
+	}
+
+	@Test
+	public final void processingException() {
+		// when
+		ProcessingException processingException = new ProcessingException(elementMock, "TEST");
+
+		// then
+		assertThat("TEST").as("Constructor must be set detailMessage field.").isEqualTo(getInternalState(processingException, "detailMessage"));
+		assertThat(elementMock).as("Constructor must be set element field.").isEqualTo(getInternalState(processingException, "element"));
+	}
+
+	@Test
+	public final void element() {
+		// when
+		ProcessingException processingException = new ProcessingException(elementMock, "TEST");
+
+		// then
+		assertThat(elementMock).as("Constructor must be set element field.").isEqualTo(processingException.element());
+	}
+
+}

--- a/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/StorIOAnnotationsProcessorDummy.java
+++ b/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/StorIOAnnotationsProcessorDummy.java
@@ -1,0 +1,110 @@
+package com.pushtorefresh.storio.common.annotations.processor;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+
+import com.pushtorefresh.storio.common.annotations.processor.generate.Generator;
+import com.pushtorefresh.storio.common.annotations.processor.introspection.StorIOColumnMeta;
+import com.pushtorefresh.storio.common.annotations.processor.introspection.StorIOTypeMeta;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.TypeSpec;
+
+@SuppressWarnings("rawtypes")
+public final class StorIOAnnotationsProcessorDummy
+		extends StorIOAnnotationsProcessor<StorIOTypeMeta, StorIOColumnMeta> {
+
+	@Override
+	protected StorIOTypeMeta processAnnotatedClass(TypeElement classElement, Elements elementUtils) {
+		return null;
+	}
+
+	@Override
+	protected void processAnnotatedFields(RoundEnvironment roundEnvironment,
+			Map<TypeElement, StorIOTypeMeta> annotatedClasses) {
+	}
+
+	@Override
+	protected StorIOColumnMeta processAnnotatedField(Element annotatedField) {
+		return null;
+	}
+
+	@Override
+	protected void validateAnnotatedClassesAndColumns(Map<TypeElement, StorIOTypeMeta> annotatedClasses) {
+	}
+
+	@Override
+	protected Class<? extends Annotation> getTypeAnnotationClass() {
+		return Annotation.class;
+	}
+
+	@Override
+	protected Class<? extends Annotation> getColumnAnnotationClass() {
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected Generator<StorIOTypeMeta> createPutResolver() {
+		Generator resolver = new Generator<StorIOTypeMeta>() {
+
+			@Override
+			public JavaFile generateJavaFile(StorIOTypeMeta storIOContentResolverTypeMeta) {
+				final TypeSpec putResolver = TypeSpec.classBuilder("TEST").build();
+
+				return JavaFile.builder("TEST", putResolver).build();
+			}
+		};
+		return resolver;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected Generator<StorIOTypeMeta> createGetResolver() {
+		Generator resolver = new Generator<StorIOTypeMeta>() {
+
+			@Override
+			public JavaFile generateJavaFile(StorIOTypeMeta storIOContentResolverTypeMeta) {
+				final TypeSpec getResolver = TypeSpec.classBuilder("TEST").build();
+
+				return JavaFile.builder("TEST", getResolver).build();
+			}
+		};
+		return resolver;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected Generator<StorIOTypeMeta> createDeleteResolver() {
+		Generator resolver = new Generator<StorIOTypeMeta>() {
+
+			@Override
+			public JavaFile generateJavaFile(StorIOTypeMeta storIOContentResolverTypeMeta) {
+				final TypeSpec deleteResolver = TypeSpec.classBuilder("TEST").build();
+
+				return JavaFile.builder("TEST", deleteResolver).build();
+			}
+		};
+		return resolver;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected Generator<StorIOTypeMeta> createMapping() {
+		Generator mapping = new Generator<StorIOTypeMeta>() {
+
+			@Override
+			public JavaFile generateJavaFile(StorIOTypeMeta storIOContentResolverTypeMeta) {
+				final TypeSpec mappingResolver = TypeSpec.classBuilder("TEST").build();
+
+				return JavaFile.builder("TEST", mappingResolver).build();
+			}
+		};
+		return mapping;
+	}
+
+}

--- a/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/StorIOAnnotationsProcessorProcessTest.java
+++ b/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/StorIOAnnotationsProcessorProcessTest.java
@@ -1,0 +1,96 @@
+package com.pushtorefresh.storio.common.annotations.processor;
+
+import static javax.tools.Diagnostic.Kind.ERROR;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.io.Writer;
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.tools.JavaFileObject;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.squareup.javapoet.JavaFile;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ JavaFile.class, JavaFileObject.class })
+public class StorIOAnnotationsProcessorProcessTest {
+
+	private StorIOAnnotationsProcessorDummy storioAnnotationsProcessor;
+	private RoundEnvironment roundEnvironmentMock;
+	private TypeElement typeElementMock;
+	private ProcessingEnvironment processingEnvironment;
+	private Set<Element> elementsAnnotatedWithStorIOType;
+
+	@Before
+	public void setUp() throws Exception {
+		storioAnnotationsProcessor = new StorIOAnnotationsProcessorDummy();
+		roundEnvironmentMock = mock(RoundEnvironment.class);
+		typeElementMock = mock(TypeElement.class);
+		processingEnvironment = mock(ProcessingEnvironment.class);
+		elementsAnnotatedWithStorIOType = new HashSet<Element>(Arrays.asList(typeElementMock));
+		doReturn(elementsAnnotatedWithStorIOType).when(roundEnvironmentMock).getElementsAnnotatedWith(Annotation.class);
+	}
+
+	@Test
+	public final void processTrue() throws Exception {
+		// given
+		Elements elementUtilsMock = mock(Elements.class);
+		when(processingEnvironment.getElementUtils()).thenReturn(elementUtilsMock);
+
+		Filer filerMock = mock(Filer.class);
+		when(processingEnvironment.getFiler()).thenReturn(filerMock);
+
+		JavaFileObject javaFileObject = mock(JavaFileObject.class);
+		when(filerMock.createSourceFile(anyString())).thenReturn(javaFileObject);
+
+		Writer writerMock = mock(Writer.class);
+		when(javaFileObject.openWriter()).thenReturn(writerMock);
+
+		storioAnnotationsProcessor.init(processingEnvironment);
+
+		// when
+		boolean result = storioAnnotationsProcessor.process(null, roundEnvironmentMock);
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	public final void processExceptionExpected() throws Exception {
+		// given
+		Messager messager = mock(Messager.class);
+		when(processingEnvironment.getMessager()).thenReturn(messager);
+
+		when(processingEnvironment.getFiler()).thenReturn(null);
+
+		storioAnnotationsProcessor.init(processingEnvironment);
+
+		// when
+		storioAnnotationsProcessor.process(null, roundEnvironmentMock);
+
+		// then
+		// Filer value set to null, filerSourceFile can't be generated and
+		// problem occures.
+		verify(messager).printMessage(ERROR, "Problem occurred with StorIOProcessor: null");
+	}
+}

--- a/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/StorIOAnnotationsProcessorTest.java
+++ b/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/StorIOAnnotationsProcessorTest.java
@@ -1,0 +1,51 @@
+package com.pushtorefresh.storio.common.annotations.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.reflect.Whitebox.getInternalState;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.tools.JavaFileObject;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.squareup.javapoet.JavaFile;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ JavaFile.class, JavaFileObject.class })
+public class StorIOAnnotationsProcessorTest {
+
+	private StorIOAnnotationsProcessorDummy storioAnnotationsProcessor;
+	private ProcessingEnvironment processingEnvironment;
+
+	@Before
+	public void setUp() throws Exception {
+		storioAnnotationsProcessor = new StorIOAnnotationsProcessorDummy();
+		processingEnvironment = mock(ProcessingEnvironment.class);
+	}
+
+	@Test
+	public final void initProcessingEnvironment() {
+		// when
+		storioAnnotationsProcessor.init(processingEnvironment);
+
+		// then
+		assertThat(processingEnvironment.getFiler()).as("init must be set filer field.").isEqualTo(getInternalState(storioAnnotationsProcessor, "filer"));
+		assertThat(processingEnvironment.getElementUtils()).as("init must be set elementUtils field.").isEqualTo(getInternalState(storioAnnotationsProcessor, "elementUtils"));
+		assertThat(processingEnvironment.getMessager()).as("init must be set messager field.").isEqualTo(getInternalState(storioAnnotationsProcessor, "messager"));
+	}
+
+	@Test
+	public final void getSupportedSourceVersion() {
+		// given
+		SourceVersion result = storioAnnotationsProcessor.getSupportedSourceVersion();
+
+		// then
+		assertThat(SourceVersion.latestSupported()).as("Function must return same result with SourceVersion.latestSupported() function.").isEqualTo(result);
+	}
+}

--- a/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/introspection/JavaTypeTest.java
+++ b/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/introspection/JavaTypeTest.java
@@ -1,12 +1,5 @@
 package com.pushtorefresh.storio.common.annotations.processor.introspection;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.junit.Test;
-
-import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
-
 import static com.pushtorefresh.storio.common.annotations.processor.introspection.JavaType.BOOLEAN;
 import static com.pushtorefresh.storio.common.annotations.processor.introspection.JavaType.BOOLEAN_OBJECT;
 import static com.pushtorefresh.storio.common.annotations.processor.introspection.JavaType.BYTE_ARRAY;
@@ -22,11 +15,24 @@ import static com.pushtorefresh.storio.common.annotations.processor.introspectio
 import static com.pushtorefresh.storio.common.annotations.processor.introspection.JavaType.SHORT_OBJECT;
 import static com.pushtorefresh.storio.common.annotations.processor.introspection.JavaType.STRING;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 public class JavaTypeTest {
 
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
     @NotNull
     private static TypeMirror mockTypeMirror(@Nullable TypeKind typeKind, @Nullable String typeName) {
         final TypeMirror typeMirror = mock(TypeMirror.class);
@@ -38,6 +44,31 @@ public class JavaTypeTest {
                 .thenReturn(typeName);
 
         return typeMirror;
+    }
+    
+    @Test
+    public void fromIllegalArgumentException() {
+    	// given
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Unsupported type: null");
+        final TypeMirror typeMirror = mock(TypeMirror.class);
+        when(typeMirror.getKind()).thenReturn(null);
+        when(typeMirror.toString()).thenReturn(null);
+
+        // when
+        JavaType.from(typeMirror);
+        
+        // then
+        fail("IllegalArgumentException expected.");
+    }
+    
+    @Test
+    public void valueOf() {
+        // when
+        JavaType javaType = JavaType.valueOf("BOOLEAN");
+        
+        // then
+        assertThat(javaType.toString()).isEqualTo("BOOLEAN");
     }
 
     @Test

--- a/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMetaTest.java
+++ b/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMetaTest.java
@@ -1,0 +1,71 @@
+package com.pushtorefresh.storio.common.annotations.processor.introspection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.reflect.Whitebox.getInternalState;
+
+import java.lang.annotation.Annotation;
+
+import javax.lang.model.element.Element;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+public class StorIOColumnMetaTest {
+
+	private Annotation annotationMock;
+	private Element elementMock;
+	private JavaType javaType;
+
+	@Before
+	public void setUp() throws Exception {
+		annotationMock = mock(Annotation.class);
+		elementMock = mock(Element.class);
+		javaType = JavaType.BOOLEAN;
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public final void constructor() {
+		// when
+		StorIOColumnMeta storioColumnMeta = new StorIOColumnMeta(elementMock, elementMock, "TEST", javaType,
+				annotationMock);
+
+		// then
+		assertThat(elementMock).as("Constructor must be set enclosingElement field.")
+				.isEqualTo(getInternalState(storioColumnMeta, "enclosingElement"));
+		assertThat(elementMock).as("Constructor must be set element field.")
+				.isEqualTo(getInternalState(storioColumnMeta, "element"));
+		assertThat("TEST").as("Constructor must be set fieldName field.")
+				.isEqualTo(getInternalState(storioColumnMeta, "fieldName"));
+		assertThat(javaType).as("Constructor must be set javaType field.")
+				.isEqualTo(getInternalState(storioColumnMeta, "javaType"));
+		assertThat(annotationMock).as("Constructor must be set storIOColumn field.")
+				.isEqualTo(getInternalState(storioColumnMeta, "storIOColumn"));
+	}
+
+	@Test
+	public final void equalsAndHashCode() {
+		EqualsVerifier.forClass(StorIOColumnMeta.class).suppress(Warning.REFERENCE_EQUALITY).usingGetClass().verify();
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public final void toStringValidation() {
+		// given
+		StorIOColumnMeta storioColumnMeta = new StorIOColumnMeta(elementMock, elementMock, "TEST", javaType,
+				annotationMock);
+		String expectedString = "StorIOColumnMeta{enclosingElement=" + elementMock + ", element=" + elementMock
+				+ ", fieldName='TEST" + '\'' + ", javaType=" + javaType + ", storIOColumn=" + annotationMock + '}';
+
+		// when
+		String toString = storioColumnMeta.toString();
+
+		// then
+		assertThat(expectedString).as("toString method should be equal with expectedString.").isEqualTo(toString);
+	}
+
+}

--- a/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOTypeMetaTest.java
+++ b/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOTypeMetaTest.java
@@ -1,0 +1,60 @@
+package com.pushtorefresh.storio.common.annotations.processor.introspection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.reflect.Whitebox.getInternalState;
+
+import java.lang.annotation.Annotation;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+public class StorIOTypeMetaTest {
+	
+	private Annotation annotationMock;
+	
+	@Before
+	public void setUp() throws Exception {
+		annotationMock = mock(Annotation.class);
+	}
+	
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public final void constructor() {
+		// when
+		StorIOTypeMeta storioTypeMeta = new StorIOTypeMeta("TEST", "TEST", annotationMock);
+		
+		// then
+		assertThat("TEST").as("Constructor must be set simpleName field.").isEqualTo(getInternalState(storioTypeMeta, "simpleName"));
+		assertThat("TEST").as("Constructor must be set packageName field.").isEqualTo(getInternalState(storioTypeMeta, "packageName"));
+		assertThat(annotationMock).as("Constructor must be set storIOType field.").isEqualTo(getInternalState(storioTypeMeta, "storIOType"));
+	}
+
+	@Test
+	public final void equalsAndHashCode() {
+		EqualsVerifier.forClass(StorIOTypeMeta.class).suppress(Warning.REFERENCE_EQUALITY).usingGetClass().verify();
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public final void toStringValitadion() {
+		// given
+		StorIOTypeMeta storioTypeMeta = new StorIOTypeMeta("TEST", "TEST", annotationMock);
+		String expectedString = "StorIOTypeMeta{" +
+                "simpleName='TEST" + '\'' +
+                ", packageName='TEST" + '\'' +
+                ", storIOType=" + annotationMock +
+                ", columns=" + getInternalState(storioTypeMeta, "columns") +
+                '}';
+		
+		// when
+		String toString = storioTypeMeta.toString();
+
+		// then
+		assertThat(expectedString).as("toString method should be equal with expectedString.").isEqualTo(toString);
+	}
+
+}


### PR DESCRIPTION
This pull request is focused on package `com.pushtorefresh.storio.common.annotations.processor`. Code coverage is measured using JaCoCo. This pull request increases code coverage of the storio-common-annotations-processor module 67%.

Metric | Before | After
------ | ------ | -----
Coverage % | 29% | 96%
Lines Covered | 45 | 157
Total Lines | 161 | 161

Please let me know if you have any questions.

Furkan
DevFactory - Code Quality Team