### PR TITLE
Find interface when no direct class found in mapper

### DIFF
--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/impl/DefaultStorIOSQLiteTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/impl/DefaultStorIOSQLiteTest.java
@@ -242,6 +242,39 @@ public class DefaultStorIOSQLiteTest {
         assertThat(storIOSQLite.internal().typeMapping(AutoValue_ConcreteEntity.class)).isSameAs(concreteEntitySQLiteTypeMapping);
     }
 
+    interface InterfaceEntity {
+    }
+
+    @Test
+    public void typeMappingShouldFindIndirectTypeMappingForInterfaces() {
+        class ConcreteEntity implements InterfaceEntity {
+        }
+
+        class Parent_ConcreteEntity extends ConcreteEntity {
+        }
+
+        //noinspection unchecked
+        final SQLiteTypeMapping<InterfaceEntity> interfaceSQLiteTypeMapping = SQLiteTypeMapping.<InterfaceEntity>builder()
+                .putResolver(mock(PutResolver.class))
+                .getResolver(mock(GetResolver.class))
+                .deleteResolver(mock(DeleteResolver.class))
+                .build();
+
+        final StorIOSQLite storIOSQLite = DefaultStorIOSQLite.builder()
+                .sqliteOpenHelper(mock(SQLiteOpenHelper.class))
+                .addTypeMapping(InterfaceEntity.class, interfaceSQLiteTypeMapping)
+                .build();
+
+        // Direct type mapping for InterfaceEntity should work
+        assertThat(storIOSQLite.internal().typeMapping(InterfaceEntity.class)).isSameAs(interfaceSQLiteTypeMapping);
+
+        // Indirect type mapping for InterfaceEntity should work
+        assertThat(storIOSQLite.internal().typeMapping(ConcreteEntity.class)).isSameAs(interfaceSQLiteTypeMapping);
+
+        // Indirect type mapping for InterfaceEntity should work with parent interface
+        assertThat(storIOSQLite.internal().typeMapping(Parent_ConcreteEntity.class)).isSameAs(interfaceSQLiteTypeMapping);
+    }
+
     @Test
     public void shouldCloseSQLiteOpenHelper() throws IOException {
         SQLiteOpenHelper sqLiteOpenHelper = mock(SQLiteOpenHelper.class);


### PR DESCRIPTION
Hello.

My application uses interface Video and different implementation of it.
I register my mapper:
```
addTypeMapping(Video.class, new VideoMapper())
```
Mapper uses only interfaces methods, I put different objects by Video interface.
For example: 
```
public class VideoImpl implements Video {}

Video video = new VideoImpl(1); 
```

I had exception when I try to put it: 
```
One of the objects from the collection does not have type mapping: object = VideoImpl{1}, object.class = VideoImpl, db was not affected by this operation, please add type mapping for this type.
```

I added finding interfaces to mapper. 
With my commit all works fine and my changes executed fast.

Thanks a lot for great library.