### PR TITLE
Enable emails from Travis to react on problems with master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,12 @@ script:
   - sh ci.sh
 
 notifications:
-  email: false
+  email:
+    recipients:
+      - artem.zinnatullin@gmail.com
+      - nikitin.da.90@gmail.com
+    on_success: never
+    on_failure: always
 
 cache:
   directories:


### PR DESCRIPTION
Previously we have status checks from GitHub which forces us to update each branch with master after each new changes in master which was a problem with many PRs.

Now I'll receive an email if PR merged into master will break the build and PRs now can be based on non-latest changes in master.

@nikitin-da PTAL