### PR TITLE
Add tests to check inserting and updating with nullable fields

### DIFF
--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/IntegrationSQLiteOpenHelper.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/IntegrationSQLiteOpenHelper.java
@@ -17,7 +17,8 @@ public class IntegrationSQLiteOpenHelper extends SQLiteOpenHelper {
     public void onCreate(@NonNull SQLiteDatabase db) {
         db.execSQL("create table " + TABLE_TEST_ITEMS + "("
                 + TestItem.COLUMN_ID + " INTEGER PRIMARY KEY, "
-                + TestItem.COLUMN_VALUE + " TEXT NOT NULL"
+                + TestItem.COLUMN_VALUE + " TEXT NOT NULL, "
+                + TestItem.COLUMN_OPTIONAL_VALUE + " TEXT"
                 + ");");
     }
 

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/TestItem.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio/contentresolver/integration/TestItem.java
@@ -30,15 +30,22 @@ class TestItem {
     @NonNull
     static final String COLUMN_VALUE = "value";
 
+    @NonNull
+    static final String COLUMN_OPTIONAL_VALUE = "optional_value";
+
     @Nullable
     private final Long id;
 
     @NonNull
     private final String value;
 
-    private TestItem(@Nullable Long id, @NonNull String value) {
+    @Nullable
+    private final String optionalValue;
+
+    private TestItem(@Nullable Long id, @NonNull String value, @Nullable String optionalValue) {
         this.id = id;
         this.value = value;
+        this.optionalValue = optionalValue;
     }
 
     @Nullable
@@ -51,6 +58,11 @@ class TestItem {
         return value;
     }
 
+    @Nullable
+    public String optionalValue() {
+        return optionalValue;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -59,17 +71,16 @@ class TestItem {
         TestItem testItem = (TestItem) o;
 
         if (id != null ? !id.equals(testItem.id) : testItem.id != null) return false;
-        return value.equals(testItem.value);
-    }
+        if (!value.equals(testItem.value)) return false;
+        return !(optionalValue != null ? !optionalValue.equals(testItem.optionalValue) : testItem.optionalValue != null);
 
-    public boolean equalsWithoutId(@NonNull TestItem object) {
-        return value.equals(object.value);
     }
 
     @Override
     public int hashCode() {
         int result = id != null ? id.hashCode() : 0;
         result = 31 * result + value.hashCode();
+        result = 31 * result + (optionalValue != null ? optionalValue.hashCode() : 0);
         return result;
     }
 
@@ -78,7 +89,13 @@ class TestItem {
         return "TestItem{" +
                 "id=" + id +
                 ", value='" + value + '\'' +
+                ", optionalValue='" + optionalValue + '\'' +
                 '}';
+    }
+
+    public boolean equalsWithoutId(@NonNull TestItem another) {
+        if (!value.equals(another.value)) return false;
+        return !(optionalValue != null ? !optionalValue.equals(another.optionalValue) : another.optionalValue != null);
     }
 
     @NonNull
@@ -87,20 +104,27 @@ class TestItem {
 
         cv.put(COLUMN_ID, id);
         cv.put(COLUMN_VALUE, value);
+        cv.put(COLUMN_OPTIONAL_VALUE, optionalValue);
 
         return cv;
     }
 
     @NonNull
     static TestItem create(@Nullable Long id, @NonNull String value) {
-        return new TestItem(id, value);
+        return create(id, value, null);
+    }
+
+    @NonNull
+    static TestItem create(@Nullable Long id, @NonNull String value, @Nullable String optionalValue) {
+        return new TestItem(id, value, optionalValue);
     }
 
     @NonNull
     static TestItem fromCursor(@NonNull Cursor cursor) {
         return create(
                 cursor.getLong(cursor.getColumnIndex(COLUMN_ID)),
-                cursor.getString(cursor.getColumnIndex(COLUMN_VALUE))
+                cursor.getString(cursor.getColumnIndex(COLUMN_VALUE)),
+                cursor.getString(cursor.getColumnIndex(COLUMN_OPTIONAL_VALUE))
         );
     }
 

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/integration/InsertTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/integration/InsertTest.java
@@ -76,4 +76,23 @@ public class InsertTest extends BaseTest {
             cursorAfterDelete.close();
         }
     }
+
+    @Test
+    public void insertOneWithNullField() {
+        User user = User.newInstance(null, "user@example.com", null); // phone is null
+        putUserBlocking(user);
+
+        final Cursor cursor = db.query(UserTableMeta.TABLE, null, null, null, null, null, null);
+
+        // asserting that values was really inserted to db
+        assertThat(cursor.getCount()).isEqualTo(1);
+        assertThat(cursor.moveToFirst()).isTrue();
+
+        final User insertedUser = UserTableMeta.GET_RESOLVER.mapFromCursor(cursor);
+
+        assertThat(insertedUser.id()).isNotNull();
+        assertThat(user.equalsExceptId(insertedUser)).isTrue();
+
+        cursor.close();
+    }
 }

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/integration/RxQueryTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/integration/RxQueryTest.java
@@ -255,7 +255,7 @@ public class RxQueryTest extends BaseTest {
 
     @Test
     public void queryOneExistedObjectTableUpdate() {
-        User expectedUser = new User(null, "such@email.com");
+        User expectedUser = User.newInstance(null, "such@email.com");
         putUsersBlocking(3);
 
         final Observable<User> userObservable = storIOSQLite

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/integration/User.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/integration/User.java
@@ -5,19 +5,27 @@ import android.support.annotation.Nullable;
 
 public class User implements Comparable<User> {
 
+    @Nullable
+    private Long id;
     @NonNull
     private final String email;
     @Nullable
-    private Long id;
+    private final String phone;
 
-    User(@Nullable Long id, @NonNull String email) {
+    User(@Nullable Long id, @NonNull String email, @Nullable String phone) {
         this.id = id;
         this.email = email;
+        this.phone = phone;
     }
 
     @NonNull
     public static User newInstance(@Nullable Long id, @NonNull String email) {
-        return new User(id, email);
+        return newInstance(id, email, null);
+    }
+
+    @NonNull
+    public static User newInstance(@Nullable Long id, @NonNull String email, @Nullable String phone) {
+        return new User(id, email, phone);
     }
 
     @Nullable
@@ -28,6 +36,11 @@ public class User implements Comparable<User> {
     @NonNull
     public String email() {
         return email;
+    }
+
+    @Nullable
+    public String phone() {
+        return phone;
     }
 
     public void setId(@Nullable Long id) {
@@ -42,26 +55,31 @@ public class User implements Comparable<User> {
         User user = (User) o;
 
         if (id != null ? !id.equals(user.id) : user.id != null) return false;
-        return email.equals(user.email);
+        if (!email.equals(user.email)) return false;
+        return !(phone != null ? !phone.equals(user.phone) : user.phone != null);
+
     }
 
     @Override
     public int hashCode() {
         int result = id != null ? id.hashCode() : 0;
         result = 31 * result + email.hashCode();
+        result = 31 * result + (phone != null ? phone.hashCode() : 0);
         return result;
     }
 
     @Override
     public String toString() {
         return "User{" +
-                "email='" + email + '\'' +
-                ", id=" + id +
+                "id=" + id +
+                ", email='" + email + '\'' +
+                ", phone='" + phone + '\'' +
                 '}';
     }
 
     public boolean equalsExceptId(@NonNull User another) {
-        return email.equals(another.email);
+        if (!email.equals(another.email)) return false;
+        return !(phone != null ? !phone.equals(another.phone) : another.phone != null);
     }
 
     @Override

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/integration/UserTableMeta.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio/sqlite/integration/UserTableMeta.java
@@ -23,11 +23,13 @@ public class UserTableMeta {
     static final String TABLE = "users";
     static final String COLUMN_ID = "_id";
     static final String COLUMN_EMAIL = "email";
+    static final String COLUMN_PHONE = "phone";
 
     // We all will be very old when Java will support string interpolation :(
     static final String SQL_CREATE_TABLE = "CREATE TABLE " + TABLE + "(" +
             COLUMN_ID + " INTEGER PRIMARY KEY, " +
-            COLUMN_EMAIL + " TEXT NOT NULL" +
+            COLUMN_EMAIL + " TEXT NOT NULL, " +
+            COLUMN_PHONE + " TEXT" + // optional
             ");";
 
     static final Query QUERY_ALL = Query.builder()
@@ -64,6 +66,7 @@ public class UserTableMeta {
 
             contentValues.put(COLUMN_ID, user.id());
             contentValues.put(COLUMN_EMAIL, user.email());
+            contentValues.put(COLUMN_PHONE, user.phone());
 
             return contentValues;
         }
@@ -86,7 +89,8 @@ public class UserTableMeta {
         public User mapFromCursor(@NonNull Cursor cursor) {
             return User.newInstance(
                     cursor.getLong(cursor.getColumnIndex(COLUMN_ID)),
-                    cursor.getString(cursor.getColumnIndex(COLUMN_EMAIL))
+                    cursor.getString(cursor.getColumnIndex(COLUMN_EMAIL)),
+                    cursor.getString(cursor.getColumnIndex(COLUMN_PHONE))
             );
         }
     };


### PR DESCRIPTION
Closes #624 
@artem-zinnatullin and @sreejithraman PTAL, please
All 3 variants are works via content resolver and sqlite directly:
- insert `null`
- update from `null` to `not null`
- update from `not null` to `null`
