### PR TITLE
Downgrade Jacoco to 0.7.2 for powermock test's coverage

### DIFF
--- a/gradle/jacoco-android.gradle
+++ b/gradle/jacoco-android.gradle
@@ -6,7 +6,10 @@ apply plugin: 'jacoco'
 
 jacoco {
     // See https://github.com/jacoco/jacoco/releases
-    toolVersion = '0.7.5.201505241946'
+    // Should to be upgraded when gradle will support jacoco v0.7.6 options/
+    // (https://github.com/gradle/gradle/pull/575/)
+    // For measure PowerMock tests coverage (https://github.com/jacoco/jacoco/pull/288).
+    toolVersion = '0.7.2.201409121644'
 }
 
 project.afterEvaluate {


### PR DESCRIPTION
Jacoco v0.7.3 break coverage for classes without location.
To fix coverage of PowerMock tests we need Jacoco v0.7.6 with this [option](https://github.com/jacoco/jacoco/pull/288) and gradle with [this](https://github.com/gradle/gradle/pull/575)  