### PR TITLE
#735 Mapping parameters by name for Kotlin and AutoValue support

### DIFF
--- a/storio-common-annotations-processor/src/main/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMeta.java
+++ b/storio-common-annotations-processor/src/main/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMeta.java
@@ -41,6 +41,7 @@ public class StorIOColumnMeta <ColumnAnnotation extends Annotation> {
         return element.getKind() == ElementKind.METHOD;
     }
 
+    @NotNull
     public String getRealElementName() {
         if (elementName.startsWith("get") && Character.isUpperCase(elementName.charAt(3))) {
             return elementName.substring(3).toLowerCase();

--- a/storio-common-annotations-processor/src/main/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMeta.java
+++ b/storio-common-annotations-processor/src/main/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMeta.java
@@ -41,6 +41,16 @@ public class StorIOColumnMeta <ColumnAnnotation extends Annotation> {
         return element.getKind() == ElementKind.METHOD;
     }
 
+    public String getRealElementName() {
+        if (elementName.startsWith("get") && Character.isUpperCase(elementName.charAt(3))) {
+            return elementName.substring(3).toLowerCase();
+        } else if (elementName.startsWith("is") && Character.isUpperCase(elementName.charAt(2))) {
+            return elementName.substring(2).toLowerCase();
+        } else {
+            return elementName;
+        }
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/storio-common-annotations-processor/src/main/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMeta.java
+++ b/storio-common-annotations-processor/src/main/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMeta.java
@@ -44,9 +44,9 @@ public class StorIOColumnMeta <ColumnAnnotation extends Annotation> {
     @NotNull
     public String getRealElementName() {
         if (elementName.startsWith("get") && Character.isUpperCase(elementName.charAt(3))) {
-            return elementName.substring(3).toLowerCase();
+            return decapitalize(elementName.substring(3));
         } else if (elementName.startsWith("is") && Character.isUpperCase(elementName.charAt(2))) {
-            return elementName.substring(2).toLowerCase();
+            return decapitalize(elementName.substring(2));
         } else {
             return elementName;
         }
@@ -86,5 +86,13 @@ public class StorIOColumnMeta <ColumnAnnotation extends Annotation> {
                 ", javaType=" + javaType +
                 ", storIOColumn=" + storIOColumn +
                 '}';
+    }
+
+    private static String decapitalize(String str) {
+        if (str.length() > 1) {
+            return Character.toLowerCase(str.charAt(0)) + str.substring(1);
+        } else {
+            return str.toLowerCase();
+        }
     }
 }

--- a/storio-common-annotations-processor/src/main/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMeta.java
+++ b/storio-common-annotations-processor/src/main/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMeta.java
@@ -88,7 +88,8 @@ public class StorIOColumnMeta <ColumnAnnotation extends Annotation> {
                 '}';
     }
 
-    private static String decapitalize(String str) {
+    @NotNull
+    private static String decapitalize(@NotNull String str) {
         if (str.length() > 1) {
             return Character.toLowerCase(str.charAt(0)) + str.substring(1);
         } else {

--- a/storio-common-annotations-processor/src/main/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOTypeMeta.java
+++ b/storio-common-annotations-processor/src/main/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOTypeMeta.java
@@ -4,10 +4,15 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
-import java.util.LinkedHashMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
 
 public class StorIOTypeMeta <TypeAnnotation extends Annotation, ColumnMeta extends StorIOColumnMeta> {
 
@@ -27,12 +32,9 @@ public class StorIOTypeMeta <TypeAnnotation extends Annotation, ColumnMeta exten
 
     /**
      * Yep, this is MODIFIABLE Map, please use it carefully.
-     * {@link LinkedHashMap} is used intentionally for building parameter list for
-     * constructor or factory method depending on ordering of methods annotated with
-     * column annotations.
      */
     @NotNull
-    public final Map<String, ColumnMeta> columns = new LinkedHashMap<String, ColumnMeta>();
+    public final Map<String, ColumnMeta> columns = new HashMap<String, ColumnMeta>();
 
     public StorIOTypeMeta(
             @NotNull String simpleName,
@@ -50,6 +52,24 @@ public class StorIOTypeMeta <TypeAnnotation extends Annotation, ColumnMeta exten
         this.packageName = packageName;
         this.storIOType = storIOType;
         this.needCreator = needCreator;
+    }
+
+    public Collection<ColumnMeta> getOrderedColumns() {
+        if (needCreator) {
+            List<String> params = new ArrayList<String>();
+            List<ColumnMeta> orderedColumns = new ArrayList<ColumnMeta>(Collections.<ColumnMeta>nCopies(columns.size(), null));
+            // creator can't be null if needCreator is true
+            //noinspection ConstantConditions
+            for (VariableElement param : creator.getParameters()) {
+                params.add(param.getSimpleName().toString());
+            }
+            for (ColumnMeta column : columns.values()) {
+                orderedColumns.set(params.indexOf(column.getRealElementName()), column);
+            }
+            return orderedColumns;
+        } else {
+            return columns.values();
+        }
     }
 
     @Override

--- a/storio-common-annotations-processor/src/main/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOTypeMeta.java
+++ b/storio-common-annotations-processor/src/main/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOTypeMeta.java
@@ -54,9 +54,10 @@ public class StorIOTypeMeta <TypeAnnotation extends Annotation, ColumnMeta exten
         this.needCreator = needCreator;
     }
 
+    @NotNull
     public Collection<ColumnMeta> getOrderedColumns() {
         if (needCreator) {
-            List<String> params = new ArrayList<String>();
+            List<String> params = new ArrayList<String>(columns.size());
             List<ColumnMeta> orderedColumns = new ArrayList<ColumnMeta>(Collections.<ColumnMeta>nCopies(columns.size(), null));
             // creator can't be null if needCreator is true
             //noinspection ConstantConditions

--- a/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMetaTest.java
+++ b/storio-common-annotations-processor/src/test/java/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMetaTest.java
@@ -68,4 +68,70 @@ public class StorIOColumnMetaTest {
 		assertThat(expectedString).as("toString method should be equal with expectedString.").isEqualTo(toString);
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public final void shouldReturnRealElementNameForElementWithoutPrefixes() {
+		StorIOColumnMeta storioColumnMeta = new StorIOColumnMeta(elementMock, elementMock, "property", javaType,
+				annotationMock);
+
+		String realName = storioColumnMeta.getRealElementName();
+
+		assertThat(realName).isEqualTo("property");
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public final void shouldReturnRealElementNameForElementWithGetPrefix() {
+		StorIOColumnMeta storioColumnMeta = new StorIOColumnMeta(elementMock, elementMock, "getProperty", javaType,
+				annotationMock);
+
+		String realName = storioColumnMeta.getRealElementName();
+
+		assertThat(realName).isEqualTo("property");
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public final void shouldReturnRealElementNameForElementWithIsPrefix() {
+		StorIOColumnMeta storioColumnMeta = new StorIOColumnMeta(elementMock, elementMock, "isProperty", javaType,
+				annotationMock);
+
+		String realName = storioColumnMeta.getRealElementName();
+
+		assertThat(realName).isEqualTo("property");
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public final void shouldReturnRealElementNameForElementWithOneCharacterName() {
+		StorIOColumnMeta storioColumnMeta = new StorIOColumnMeta(elementMock, elementMock, "a", javaType,
+				annotationMock);
+
+		String realName = storioColumnMeta.getRealElementName();
+
+		assertThat(realName).isEqualTo("a");
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public final void shouldReturnRealElementNameForElementStartsWithGet() {
+		StorIOColumnMeta storioColumnMeta = new StorIOColumnMeta(elementMock, elementMock, "getter", javaType,
+				annotationMock);
+
+		String realName = storioColumnMeta.getRealElementName();
+
+		assertThat(realName).isEqualTo("getter");
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public final void shouldReturnRealElementNameForElementStartsWithIs() {
+		StorIOColumnMeta storioColumnMeta = new StorIOColumnMeta(elementMock, elementMock, "iso", javaType,
+				annotationMock);
+
+		String realName = storioColumnMeta.getRealElementName();
+
+		assertThat(realName).isEqualTo("iso");
+	}
+
 }

--- a/storio-sqlite-annotations-processor/src/main/java/com/pushtorefresh/storio/sqlite/annotations/processor/generate/GetResolverGenerator.java
+++ b/storio-sqlite-annotations-processor/src/main/java/com/pushtorefresh/storio/sqlite/annotations/processor/generate/GetResolverGenerator.java
@@ -101,12 +101,10 @@ public class GetResolverGenerator implements Generator<StorIOSQLiteTypeMeta> {
                         .build())
                 .addCode("\n");
 
-        // We don't know the name of the variable, just the type. So just use generic parameter names
-        int paramCount = 1;
         final StringBuilder paramsBuilder = new StringBuilder();
         paramsBuilder.append("(");
         boolean first = true;
-        for (final StorIOSQLiteColumnMeta columnMeta : storIOSQLiteTypeMeta.columns.values()) {
+        for (final StorIOSQLiteColumnMeta columnMeta : storIOSQLiteTypeMeta.getOrderedColumns()) {
             final String columnIndex = "cursor.getColumnIndex(\"" + columnMeta.storIOColumn.name() + "\")";
 
             final JavaType javaType = columnMeta.javaType;
@@ -117,21 +115,19 @@ public class GetResolverGenerator implements Generator<StorIOSQLiteTypeMeta> {
 
             final boolean isBoxed = javaType.isBoxedType();
             if (isBoxed) { // otherwise -> if primitive and value from cursor null -> fail early
-                builder.addStatement("$T param" + paramCount + " = null", name);
+                builder.addStatement("$T" + columnMeta.getRealElementName() + "= null", name);
                 builder.beginControlFlow("if(!cursor.isNull($L))", columnIndex);
-                builder.addStatement("param" + paramCount + " = cursor.$L", getFromCursor);
+                builder.addStatement(columnMeta.getRealElementName() + " = cursor.$L", getFromCursor);
                 builder.endControlFlow();
             } else {
-                builder.addStatement("$T param" + paramCount + " = cursor.$L", name, getFromCursor);
+                builder.addStatement("$T " + columnMeta.getRealElementName() + " = cursor.$L", name, getFromCursor);
             }
 
             if (!first) {
                 paramsBuilder.append(", ");
             }
             first = false;
-            paramsBuilder.append("param" + paramCount);
-
-            paramCount++;
+            paramsBuilder.append(columnMeta.getRealElementName());
         }
         paramsBuilder.append(")");
         builder.addCode("\n");


### PR DESCRIPTION
https://github.com/pushtorefresh/storio/issues/735
The only limitation is that in order to make it work for Kotlin you need to use [kapt2](https://blog.jetbrains.com/kotlin/2016/09/kotlin-1-0-4-is-here/) since kapt1 can't get actual names of parameters.