### PR TITLE
Add missing annotation to Kotlin's example in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ public abstract class Tweet {
 
 `Kotlin`
 ```kotlin
-data class Tweet @StorIOSQLiteCreator constructor(@get:StorIOSQLiteColumn(name = "author") val author: String,
+@StorIOSQLiteType(table = "tweets") data class Tweet @StorIOSQLiteCreator constructor(@get:StorIOSQLiteColumn(name = "author") val author: String,
                                                   @get:StorIOSQLiteColumn(name = "content") val content: String)
 ```
 


### PR DESCRIPTION
I got compile error without `@StorIOSQLiteType` annotation so I guess it's needed actually.