### PR TITLE
Fixes for resolver generators

### DIFF
--- a/storio-content-resolver-annotations-processor/src/main/java/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/GetResolverGenerator.java
+++ b/storio-content-resolver-annotations-processor/src/main/java/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/GetResolverGenerator.java
@@ -72,7 +72,7 @@ public class GetResolverGenerator implements Generator<StorIOContentResolverType
 
             final boolean isBoxed = javaType.isBoxedType();
             if (isBoxed) { // otherwise -> if primitive and value from cursor null -> fail early
-                builder.beginControlFlow("if(!cursor.isNull($L))", columnIndex);
+                builder.beginControlFlow("if (!cursor.isNull($L))", columnIndex);
             }
 
             builder.addStatement("object.$L = cursor.$L", columnMeta.elementName, getFromCursor);
@@ -115,12 +115,12 @@ public class GetResolverGenerator implements Generator<StorIOContentResolverType
 
             final boolean isBoxed = javaType.isBoxedType();
             if (isBoxed) { // otherwise -> if primitive and value from cursor null -> fail early
-                builder.addStatement("$T " + columnMeta.getRealElementName() + " = null", name);
-                builder.beginControlFlow("if(!cursor.isNull($L))", columnIndex);
-                builder.addStatement(columnMeta.getRealElementName() + " = cursor.$L", getFromCursor);
+                builder.addStatement("$T $L = null", name, columnMeta.getRealElementName());
+                builder.beginControlFlow("if (!cursor.isNull($L))", columnIndex);
+                builder.addStatement("$L = cursor.$L", columnMeta.getRealElementName(), getFromCursor);
                 builder.endControlFlow();
             } else {
-                builder.addStatement("$T " + columnMeta.getRealElementName() + " = cursor.$L", name, getFromCursor);
+                builder.addStatement("$T $L = cursor.$L", name, columnMeta.getRealElementName(), getFromCursor);
             }
 
             if (!first) {
@@ -135,7 +135,8 @@ public class GetResolverGenerator implements Generator<StorIOContentResolverType
         if (storIOContentResolverTypeMeta.creator.getKind() == ElementKind.CONSTRUCTOR) {
             builder.addStatement("$T object = new $T" + paramsBuilder.toString(), storIOSQLiteTypeClassName, storIOSQLiteTypeClassName);
         } else {
-            builder.addStatement("$T object = $T." + storIOContentResolverTypeMeta.creator.getSimpleName() + paramsBuilder.toString(), storIOSQLiteTypeClassName, storIOSQLiteTypeClassName);
+            builder.addStatement("$T object = $T." + storIOContentResolverTypeMeta.creator.getSimpleName() + paramsBuilder.toString(),
+                    storIOSQLiteTypeClassName, storIOSQLiteTypeClassName);
         }
 
         return builder

--- a/storio-content-resolver-annotations-processor/src/main/java/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/GetResolverGenerator.java
+++ b/storio-content-resolver-annotations-processor/src/main/java/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/GetResolverGenerator.java
@@ -135,8 +135,8 @@ public class GetResolverGenerator implements Generator<StorIOContentResolverType
         if (storIOContentResolverTypeMeta.creator.getKind() == ElementKind.CONSTRUCTOR) {
             builder.addStatement("$T object = new $T" + paramsBuilder.toString(), storIOSQLiteTypeClassName, storIOSQLiteTypeClassName);
         } else {
-            builder.addStatement("$T object = $T." + storIOContentResolverTypeMeta.creator.getSimpleName() + paramsBuilder.toString(),
-                    storIOSQLiteTypeClassName, storIOSQLiteTypeClassName);
+            builder.addStatement("$T object = $T.$L", storIOSQLiteTypeClassName, storIOSQLiteTypeClassName,
+                    storIOContentResolverTypeMeta.creator.getSimpleName() + paramsBuilder.toString());
         }
 
         return builder

--- a/storio-content-resolver-annotations-processor/src/main/java/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/PutResolverGenerator.java
+++ b/storio-content-resolver-annotations-processor/src/main/java/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/PutResolverGenerator.java
@@ -116,12 +116,12 @@ public class PutResolverGenerator implements Generator<StorIOContentResolverType
         for (final StorIOContentResolverColumnMeta columnMeta : storIOContentResolverTypeMeta.columns.values()) {
             final boolean ignoreNull = columnMeta.storIOColumn.ignoreNull();
             if (ignoreNull) {
-                builder.beginControlFlow("if($L != null)", "object." + columnMeta.elementName);
+                builder.beginControlFlow("if (object.$L != null)", columnMeta.elementName + (columnMeta.isMethod() ? "()" : ""));
             }
             builder.addStatement(
-                    "contentValues.put($S, $L)",
+                    "contentValues.put($S, object.$L)",
                     columnMeta.storIOColumn.name(),
-                    "object." + columnMeta.elementName + (columnMeta.isMethod() ? "()" : "")
+                    columnMeta.elementName + (columnMeta.isMethod() ? "()" : "")
             );
             if (ignoreNull) {
                 builder.endControlFlow();

--- a/storio-content-resolver-annotations-processor/src/test/java/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/GetResolverGeneratorTest.java
+++ b/storio-content-resolver-annotations-processor/src/test/java/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/GetResolverGeneratorTest.java
@@ -145,7 +145,7 @@ public class GetResolverGeneratorTest {
                         "        TestItem object = new TestItem();\n" +
                         "\n" +
                         "        object.field1 = cursor.getInt(cursor.getColumnIndex(\"column1\")) == 1;\n" +
-                        "        if(!cursor.isNull(cursor.getColumnIndex(\"column2\"))) {\n" +
+                        "        if (!cursor.isNull(cursor.getColumnIndex(\"column2\"))) {\n" +
                         "            object.field2 = cursor.getInt(cursor.getColumnIndex(\"column2\"));\n" +
                         "        }\n" +
                         "\n" +

--- a/storio-content-resolver-annotations-processor/src/test/java/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/PutResolverGeneratorTest.java
+++ b/storio-content-resolver-annotations-processor/src/test/java/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/PutResolverGeneratorTest.java
@@ -346,7 +346,7 @@ public class PutResolverGeneratorTest {
                         "        ContentValues contentValues = new ContentValues(2);\n" +
                         "\n" +
                         "        contentValues.put(\"column1\", object.column1Field);\n" +
-                        "        if(object.column2Field != null) {\n" +                         // check for null added
+                        "        if (object.column2Field != null) {\n" +                         // check for null added
                         "            contentValues.put(\"column2\", object.column2Field);\n" +
                         "        }\n" +
                         "\n" +

--- a/storio-sqlite-annotations-processor/src/main/java/com/pushtorefresh/storio/sqlite/annotations/processor/generate/GetResolverGenerator.java
+++ b/storio-sqlite-annotations-processor/src/main/java/com/pushtorefresh/storio/sqlite/annotations/processor/generate/GetResolverGenerator.java
@@ -72,7 +72,7 @@ public class GetResolverGenerator implements Generator<StorIOSQLiteTypeMeta> {
 
             final boolean isBoxed = javaType.isBoxedType();
             if (isBoxed) { // otherwise -> if primitive and value from cursor null -> fail early
-                builder.beginControlFlow("if(!cursor.isNull($L))", columnIndex);
+                builder.beginControlFlow("if (!cursor.isNull($L))", columnIndex);
             }
 
             builder.addStatement("object.$L = cursor.$L", columnMeta.elementName, getFromCursor);
@@ -115,12 +115,12 @@ public class GetResolverGenerator implements Generator<StorIOSQLiteTypeMeta> {
 
             final boolean isBoxed = javaType.isBoxedType();
             if (isBoxed) { // otherwise -> if primitive and value from cursor null -> fail early
-                builder.addStatement("$T" + columnMeta.getRealElementName() + "= null", name);
-                builder.beginControlFlow("if(!cursor.isNull($L))", columnIndex);
-                builder.addStatement(columnMeta.getRealElementName() + " = cursor.$L", getFromCursor);
+                builder.addStatement("$T $L = null", name, columnMeta.getRealElementName());
+                builder.beginControlFlow("if (!cursor.isNull($L))", columnIndex);
+                builder.addStatement("$L = cursor.$L", columnMeta.getRealElementName(), getFromCursor);
                 builder.endControlFlow();
             } else {
-                builder.addStatement("$T " + columnMeta.getRealElementName() + " = cursor.$L", name, getFromCursor);
+                builder.addStatement("$T $L = cursor.$L", name, columnMeta.getRealElementName(), getFromCursor);
             }
 
             if (!first) {
@@ -135,7 +135,8 @@ public class GetResolverGenerator implements Generator<StorIOSQLiteTypeMeta> {
         if (storIOSQLiteTypeMeta.creator.getKind() == ElementKind.CONSTRUCTOR) {
             builder.addStatement("$T object = new $T" + paramsBuilder.toString(), storIOSQLiteTypeClassName, storIOSQLiteTypeClassName);
         } else {
-            builder.addStatement("$T object = $T." + storIOSQLiteTypeMeta.creator.getSimpleName() + paramsBuilder.toString(), storIOSQLiteTypeClassName, storIOSQLiteTypeClassName);
+            builder.addStatement("$T object = $T.$L", storIOSQLiteTypeMeta.creator.getSimpleName() + paramsBuilder.toString(),
+                    storIOSQLiteTypeClassName, storIOSQLiteTypeClassName);
         }
 
         return builder

--- a/storio-sqlite-annotations-processor/src/main/java/com/pushtorefresh/storio/sqlite/annotations/processor/generate/GetResolverGenerator.java
+++ b/storio-sqlite-annotations-processor/src/main/java/com/pushtorefresh/storio/sqlite/annotations/processor/generate/GetResolverGenerator.java
@@ -135,8 +135,8 @@ public class GetResolverGenerator implements Generator<StorIOSQLiteTypeMeta> {
         if (storIOSQLiteTypeMeta.creator.getKind() == ElementKind.CONSTRUCTOR) {
             builder.addStatement("$T object = new $T" + paramsBuilder.toString(), storIOSQLiteTypeClassName, storIOSQLiteTypeClassName);
         } else {
-            builder.addStatement("$T object = $T.$L", storIOSQLiteTypeMeta.creator.getSimpleName() + paramsBuilder.toString(),
-                    storIOSQLiteTypeClassName, storIOSQLiteTypeClassName);
+            builder.addStatement("$T object = $T.$L", storIOSQLiteTypeClassName, storIOSQLiteTypeClassName,
+                    storIOSQLiteTypeMeta.creator.getSimpleName() + paramsBuilder.toString());
         }
 
         return builder

--- a/storio-sqlite-annotations-processor/src/main/java/com/pushtorefresh/storio/sqlite/annotations/processor/generate/PutResolverGenerator.java
+++ b/storio-sqlite-annotations-processor/src/main/java/com/pushtorefresh/storio/sqlite/annotations/processor/generate/PutResolverGenerator.java
@@ -105,12 +105,12 @@ public class PutResolverGenerator implements Generator<StorIOSQLiteTypeMeta> {
         for (StorIOSQLiteColumnMeta columnMeta : storIOSQLiteTypeMeta.columns.values()) {
             final boolean ignoreNull = columnMeta.storIOColumn.ignoreNull();
             if (ignoreNull) {
-                builder.beginControlFlow("if($L != null)", "object." + columnMeta.elementName);
+                builder.beginControlFlow("if (object.$L != null)", columnMeta.elementName + (columnMeta.isMethod() ? "()" : ""));
             }
             builder.addStatement(
-                    "contentValues.put($S, $L)",
+                    "contentValues.put($S, object.$L)",
                     columnMeta.storIOColumn.name(),
-                    "object." + columnMeta.elementName + (columnMeta.isMethod() ? "()" : "")
+                    columnMeta.elementName + (columnMeta.isMethod() ? "()" : "")
             );
             if (ignoreNull) {
                 builder.endControlFlow();

--- a/storio-sqlite-annotations-processor/src/test/java/com/pushtorefresh/storio/sqlite/annotations/processor/generate/GetResolverGeneratorTest.java
+++ b/storio-sqlite-annotations-processor/src/test/java/com/pushtorefresh/storio/sqlite/annotations/processor/generate/GetResolverGeneratorTest.java
@@ -152,7 +152,7 @@ public class GetResolverGeneratorTest {
                         "        TestItem object = new TestItem();\n" +
                         "\n" +
                         "        object.field1 = cursor.getInt(cursor.getColumnIndex(\"column1\")) == 1;\n" +
-                        "        if(!cursor.isNull(cursor.getColumnIndex(\"column2\"))) {\n" +
+                        "        if (!cursor.isNull(cursor.getColumnIndex(\"column2\"))) {\n" +
                         "            object.field2 = cursor.getInt(cursor.getColumnIndex(\"column2\"));\n" +
                         "        }\n" +
                         "\n" +

--- a/storio-sqlite-annotations-processor/src/test/java/com/pushtorefresh/storio/sqlite/annotations/processor/generate/PutResolverGeneratorTest.java
+++ b/storio-sqlite-annotations-processor/src/test/java/com/pushtorefresh/storio/sqlite/annotations/processor/generate/PutResolverGeneratorTest.java
@@ -174,7 +174,7 @@ public class PutResolverGeneratorTest {
                         "        ContentValues contentValues = new ContentValues(2);\n" +
                         "\n" +
                         "        contentValues.put(\"column1\", object.column1Field);\n" +
-                        "        if(object.column2Field != null) {\n" +                         // check for null added
+                        "        if (object.column2Field != null) {\n" +                         // check for null added
                         "            contentValues.put(\"column2\", object.column2Field);\n" +
                         "        }\n" +
                         "\n" +


### PR DESCRIPTION
Fix for this https://github.com/pushtorefresh/storio/issues/749 issue.
And also I discovered error when column annotation with `ignoreNull = true` applied on getter.
Also improved some code which was using concatenation instead of formatting.