### PR TITLE
Support for Kotlin properties

### DIFF
--- a/storio-common-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/common/annotations/processor/Extensions.kt
+++ b/storio-common-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/common/annotations/processor/Extensions.kt
@@ -1,0 +1,4 @@
+package com.pushtorefresh.storio.common.annotations.processor
+
+fun String.startsWithIs(): Boolean = this.startsWith("is") && this.length > 2
+        && Character.isUpperCase(this[2])

--- a/storio-common-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMeta.kt
+++ b/storio-common-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMeta.kt
@@ -9,7 +9,9 @@ open class StorIOColumnMeta<out ColumnAnnotation : Annotation>(
         val element: Element,
         val elementName: String,
         val javaType: JavaType,
-        val storIOColumn: ColumnAnnotation) {
+        val storIOColumn: ColumnAnnotation,
+        val getter: String? = null,
+        val setter: String? = null) {
 
     val isMethod: Boolean
         get() = element.kind == ElementKind.METHOD
@@ -18,6 +20,16 @@ open class StorIOColumnMeta<out ColumnAnnotation : Annotation>(
         get() = when {
             elementName.startsWith("get") && isUpperCase(elementName[3]) -> decapitalize(elementName.substring(3))
             elementName.startsWith("is") && isUpperCase(elementName[2]) -> decapitalize(elementName.substring(2))
+            else -> elementName
+        }
+
+    val needAccessors: Boolean
+        get() = getter != null && setter != null
+
+    val contextAwareName: String
+        get() = when {
+            isMethod -> "$elementName()"
+            needAccessors -> "$getter()"
             else -> elementName
         }
 
@@ -32,6 +44,8 @@ open class StorIOColumnMeta<out ColumnAnnotation : Annotation>(
         if (elementName != other.elementName) return false
         if (javaType != other.javaType) return false
         if (storIOColumn != other.storIOColumn) return false
+        if (getter != other.getter) return false
+        if (setter != other.setter) return false
 
         return true
     }
@@ -42,10 +56,12 @@ open class StorIOColumnMeta<out ColumnAnnotation : Annotation>(
         result = 31 * result + elementName.hashCode()
         result = 31 * result + javaType.hashCode()
         result = 31 * result + storIOColumn.hashCode()
+        result = 31 * result + (getter?.hashCode() ?: 0)
+        result = 31 * result + (setter?.hashCode() ?: 0)
         return result
     }
 
-    override fun toString() = "StorIOColumnMeta(enclosingElement=$enclosingElement, element=$element, elementName='$elementName', javaType=$javaType, storIOColumn=$storIOColumn)"
+    override fun toString(): String = "StorIOColumnMeta(enclosingElement=$enclosingElement, element=$element, elementName='$elementName', javaType=$javaType, storIOColumn=$storIOColumn, getter='$getter', setter='$setter')"
 
     private fun decapitalize(str: String) = when {
         str.length > 1 -> Character.toLowerCase(str[0]) + str.substring(1)

--- a/storio-common-annotations-processor/src/test/kotlin/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMetaTest.kt
+++ b/storio-common-annotations-processor/src/test/kotlin/com/pushtorefresh/storio/common/annotations/processor/introspection/StorIOColumnMetaTest.kt
@@ -45,10 +45,8 @@ class StorIOColumnMetaTest {
     @Test
     fun toStringValidation() {
         // given
-        val columnMeta = StorIOColumnMeta(elementMock, elementMock, "TEST", javaType, annotationMock)
-        val expectedString = "StorIOColumnMeta(enclosingElement=$elementMock," +
-                " element=$elementMock, elementName='TEST', javaType=" + javaType +
-                ", storIOColumn=" + annotationMock + ')'
+        val columnMeta = StorIOColumnMeta(elementMock, elementMock, "TEST", javaType, annotationMock, "getter", "setter")
+        val expectedString = "StorIOColumnMeta(enclosingElement=$elementMock, element=$elementMock, elementName='TEST', javaType=$javaType, storIOColumn=$annotationMock, getter='getter', setter='setter')"
 
         // when
         val toString = columnMeta.toString()

--- a/storio-content-resolver-annotations-processor-test/src/test/java/com/pushtorefresh/storio/contentresolver/annotations/processor/test/StorIOContentResolverAnnotationsProcessorTest.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/java/com/pushtorefresh/storio/contentresolver/annotations/processor/test/StorIOContentResolverAnnotationsProcessorTest.java
@@ -70,14 +70,25 @@ public class StorIOContentResolverAnnotationsProcessorTest {
     }
 
     @Test
-    public void shouldNotCompileIfAnnotatedFieldIsPrivate() {
-        JavaFileObject model = JavaFileObjects.forResource("PrivateField.java");
+    public void shouldNotCompileIfAnnotatedFieldIsPrivateAndDoesNotHaveAccessors() {
+        JavaFileObject model = JavaFileObjects.forResource("PrivateFieldWithoutAccessors.java");
 
         assert_().about(javaSource())
                 .that(model)
                 .processedWith(new StorIOContentResolverProcessor())
                 .failsToCompile()
-                .withErrorContaining("StorIOContentResolverColumn can not be applied to private field or method: id");
+                .withErrorContaining("StorIOContentResolverColumn can not be applied to private field without corresponding getter and setter or private method: id");
+    }
+
+    @Test
+    public void shouldNotCompileIfAnnotatedMethodIsPrivate() {
+        JavaFileObject model = JavaFileObjects.forResource("PrivateMethod.java");
+
+        assert_().about(javaSource())
+                .that(model)
+                .processedWith(new StorIOContentResolverProcessor())
+                .failsToCompile()
+                .withErrorContaining("StorIOContentResolverColumn can not be applied to private field without corresponding getter and setter or private method: id");
     }
 
     @Test
@@ -496,4 +507,96 @@ public class StorIOContentResolverAnnotationsProcessorTest {
                 .generatesSources(generatedTypeMapping, generatedDeleteResolver, generatedGetResolver, generatedPutResolver);
     }
 
+    @Test
+    public void shouldNotCompileIfAnnotatedFieldIsPrivateAndDoesNotHaveSetter() {
+        JavaFileObject model = JavaFileObjects.forResource("PrivateFieldWithoutSetter.java");
+
+        assert_().about(javaSource())
+                .that(model)
+                .processedWith(new StorIOContentResolverProcessor())
+                .failsToCompile()
+                .withErrorContaining("StorIOContentResolverColumn can not be applied to private field without corresponding getter and setter or private method: id");
+    }
+
+    @Test
+    public void shouldNotCompileIfAnnotatedFieldIsPrivateAndDoesNotHaveGetter() {
+        JavaFileObject model = JavaFileObjects.forResource("PrivateFieldWithoutGetter.java");
+
+        assert_().about(javaSource())
+                .that(model)
+                .processedWith(new StorIOContentResolverProcessor())
+                .failsToCompile()
+                .withErrorContaining("StorIOContentResolverColumn can not be applied to private field without corresponding getter and setter or private method: id");
+    }
+
+    @Test
+    public void shouldCompileIfAnnotatedFieldIsPrivateAndHasIsGetter() {
+        JavaFileObject model = JavaFileObjects.forResource("PrivateFieldWithIsGetter.java");
+
+        assert_().about(javaSource())
+                .that(model)
+                .processedWith(new StorIOContentResolverProcessor())
+                .compilesWithoutError();
+    }
+
+    @Test
+    public void shouldCompileIfAnnotatedFieldIsPrivateAndHasNameStartingWithIs() {
+        JavaFileObject model = JavaFileObjects.forResource("PrivateFieldWithNameStartingWithIs.java");
+
+        assert_().about(javaSource())
+                .that(model)
+                .processedWith(new StorIOContentResolverProcessor())
+                .compilesWithoutError();
+    }
+
+    @Test
+    public void shouldCompileWithPrivatePrimitiveFieldsWithCorrepsondingAccessors() {
+        JavaFileObject model = JavaFileObjects.forResource("PrimitivePrivateFields.java");
+
+        JavaFileObject generatedTypeMapping = JavaFileObjects.forResource("PrimitivePrivateFieldsContentResolverTypeMapping.java");
+        JavaFileObject generatedDeleteResolver = JavaFileObjects.forResource("PrimitivePrivateFieldsStorIOContentResolverDeleteResolver.java");
+        JavaFileObject generatedGetResolver = JavaFileObjects.forResource("PrimitivePrivateFieldsStorIOContentResolverGetResolver.java");
+        JavaFileObject generatedPutResolver = JavaFileObjects.forResource("PrimitivePrivateFieldsStorIOContentResolverPutResolver.java");
+
+        assert_().about(javaSource())
+                .that(model)
+                .processedWith(new StorIOContentResolverProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(generatedTypeMapping, generatedDeleteResolver, generatedGetResolver, generatedPutResolver);
+    }
+
+    @Test
+    public void shouldCompileWithPrivateBoxedTypesFieldsWithCorrespondingAccessors() {
+        JavaFileObject model = JavaFileObjects.forResource("BoxedTypesPrivateFields.java");
+
+        JavaFileObject generatedTypeMapping = JavaFileObjects.forResource("BoxedTypesPrivateFieldsContentResolverTypeMapping.java");
+        JavaFileObject generatedDeleteResolver = JavaFileObjects.forResource("BoxedTypesPrivateFieldsStorIOContentResolverDeleteResolver.java");
+        JavaFileObject generatedGetResolver = JavaFileObjects.forResource("BoxedTypesPrivateFieldsStorIOContentResolverGetResolver.java");
+        JavaFileObject generatedPutResolver = JavaFileObjects.forResource("BoxedTypesPrivateFieldsStorIOContentResolverPutResolver.java");
+
+        assert_().about(javaSource())
+                .that(model)
+                .processedWith(new StorIOContentResolverProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(generatedTypeMapping, generatedDeleteResolver, generatedGetResolver, generatedPutResolver);
+    }
+
+    @Test
+    public void shouldCompileWithPrivateBoxedTypesFieldsWithCorresondingAccessorsAndMarkedAsIgnoreNull() {
+        JavaFileObject model = JavaFileObjects.forResource("BoxedTypesPrivateFieldsIgnoreNull.java");
+
+        JavaFileObject generatedTypeMapping = JavaFileObjects.forResource("BoxedTypesPrivateFieldsIgnoreNullContentResolverTypeMapping.java");
+        JavaFileObject generatedDeleteResolver = JavaFileObjects.forResource("BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverDeleteResolver.java");
+        JavaFileObject generatedGetResolver = JavaFileObjects.forResource("BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverGetResolver.java");
+        JavaFileObject generatedPutResolver = JavaFileObjects.forResource("BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverPutResolver.java");
+
+        assert_().about(javaSource())
+                .that(model)
+                .processedWith(new StorIOContentResolverProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(generatedTypeMapping, generatedDeleteResolver, generatedGetResolver, generatedPutResolver);
+    }
 }

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFields.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFields.java
@@ -1,0 +1,71 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+@StorIOContentResolverType(uri = "content://uri")
+public class BoxedTypesPrivateFields {
+
+    @StorIOContentResolverColumn(name = "field1")
+    private Boolean field1;
+
+    @StorIOContentResolverColumn(name = "field2")
+    private Short field2;
+
+    @StorIOContentResolverColumn(name = "field3")
+    private Integer field3;
+
+    @StorIOContentResolverColumn(name = "field4", key = true)
+    private Long field4;
+
+    @StorIOContentResolverColumn(name = "field5")
+    private Float field5;
+
+    @StorIOContentResolverColumn(name = "field6")
+    private Double field6;
+
+    public Boolean getField1() {
+        return field1;
+    }
+
+    public void setField1(Boolean field1) {
+        this.field1 = field1;
+    }
+
+    public Short getField2() {
+        return field2;
+    }
+
+    public void setField2(Short field2) {
+        this.field2 = field2;
+    }
+
+    public Integer getField3() {
+        return field3;
+    }
+
+    public void setField3(Integer field3) {
+        this.field3 = field3;
+    }
+
+    public Long getField4() {
+        return field4;
+    }
+
+    public void setField4(Long field4) {
+        this.field4 = field4;
+    }
+
+    public Float getField5() {
+        return field5;
+    }
+
+    public void setField5(Float field5) {
+        this.field5 = field5;
+    }
+
+    public Double getField6() {
+        return field6;
+    }
+
+    public void setField6(Double field6) {
+        this.field6 = field6;
+    }
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsContentResolverTypeMapping.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsContentResolverTypeMapping.java
@@ -1,0 +1,14 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+import com.pushtorefresh.storio.contentresolver.ContentResolverTypeMapping;
+
+/**
+ * Generated mapping with collection of resolvers
+ */
+public class BoxedTypesPrivateFieldsContentResolverTypeMapping extends ContentResolverTypeMapping<BoxedTypesPrivateFields> {
+    public BoxedTypesPrivateFieldsContentResolverTypeMapping() {
+        super(new BoxedTypesPrivateFieldsStorIOContentResolverPutResolver(),
+                new BoxedTypesPrivateFieldsStorIOContentResolverGetResolver(),
+                new BoxedTypesPrivateFieldsStorIOContentResolverDeleteResolver());
+    }
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNull.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNull.java
@@ -1,0 +1,71 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+@StorIOContentResolverType(uri = "content://uri")
+public class BoxedTypesPrivateFieldsIgnoreNull {
+
+    @StorIOContentResolverColumn(name = "field1", ignoreNull = true)
+    private Boolean field1;
+
+    @StorIOContentResolverColumn(name = "field2", ignoreNull = true)
+    private Short field2;
+
+    @StorIOContentResolverColumn(name = "field3", ignoreNull = true)
+    private Integer field3;
+
+    @StorIOContentResolverColumn(name = "field4", key = true, ignoreNull = true)
+    private Long field4;
+
+    @StorIOContentResolverColumn(name = "field5", ignoreNull = true)
+    private Float field5;
+
+    @StorIOContentResolverColumn(name = "field6", ignoreNull = true)
+    private Double field6;
+
+    public Boolean getField1() {
+        return field1;
+    }
+
+    public void setField1(Boolean field1) {
+        this.field1 = field1;
+    }
+
+    public Short getField2() {
+        return field2;
+    }
+
+    public void setField2(Short field2) {
+        this.field2 = field2;
+    }
+
+    public Integer getField3() {
+        return field3;
+    }
+
+    public void setField3(Integer field3) {
+        this.field3 = field3;
+    }
+
+    public Long getField4() {
+        return field4;
+    }
+
+    public void setField4(Long field4) {
+        this.field4 = field4;
+    }
+
+    public Float getField5() {
+        return field5;
+    }
+
+    public void setField5(Float field5) {
+        this.field5 = field5;
+    }
+
+    public Double getField6() {
+        return field6;
+    }
+
+    public void setField6(Double field6) {
+        this.field6 = field6;
+    }
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullContentResolverTypeMapping.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullContentResolverTypeMapping.java
@@ -1,0 +1,14 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+import com.pushtorefresh.storio.contentresolver.ContentResolverTypeMapping;
+
+/**
+ * Generated mapping with collection of resolvers
+ */
+public class BoxedTypesPrivateFieldsIgnoreNullContentResolverTypeMapping extends ContentResolverTypeMapping<BoxedTypesPrivateFieldsIgnoreNull> {
+    public BoxedTypesPrivateFieldsIgnoreNullContentResolverTypeMapping() {
+        super(new BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverPutResolver(),
+                new BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverGetResolver(),
+                new BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverDeleteResolver());
+    }
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverDeleteResolver.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverDeleteResolver.java
@@ -1,0 +1,23 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.contentresolver.operations.delete.DefaultDeleteResolver;
+import com.pushtorefresh.storio.contentresolver.queries.DeleteQuery;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Delete Operation
+ */
+public class BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverDeleteResolver extends DefaultDeleteResolver<BoxedTypesPrivateFieldsIgnoreNull> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public DeleteQuery mapToDeleteQuery(@NonNull BoxedTypesPrivateFieldsIgnoreNull object) {
+        return DeleteQuery.builder()
+                .uri("content://uri")
+                .where("field4 = ?")
+                .whereArgs(object.getField4())
+                .build();}
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverGetResolver.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverGetResolver.java
@@ -1,0 +1,41 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.contentresolver.operations.get.DefaultGetResolver;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Get Operation
+ */
+public class BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverGetResolver extends DefaultGetResolver<BoxedTypesPrivateFieldsIgnoreNull> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public BoxedTypesPrivateFieldsIgnoreNull mapFromCursor(@NonNull Cursor cursor) {
+        BoxedTypesPrivateFieldsIgnoreNull object = new BoxedTypesPrivateFieldsIgnoreNull();
+
+        if (!cursor.isNull(cursor.getColumnIndex("field1"))) {
+            object.setField1(cursor.getInt(cursor.getColumnIndex("field1")) == 1);
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field2"))) {
+            object.setField2(cursor.getShort(cursor.getColumnIndex("field2")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field3"))) {
+            object.setField3(cursor.getInt(cursor.getColumnIndex("field3")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field4"))) {
+            object.setField4(cursor.getLong(cursor.getColumnIndex("field4")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field5"))) {
+            object.setField5(cursor.getFloat(cursor.getColumnIndex("field5")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field6"))) {
+            object.setField6(cursor.getDouble(cursor.getColumnIndex("field6")));
+        }
+
+        return object;
+    }
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverPutResolver.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverPutResolver.java
@@ -1,0 +1,65 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+import android.content.ContentValues;
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.contentresolver.operations.put.DefaultPutResolver;
+import com.pushtorefresh.storio.contentresolver.queries.InsertQuery;
+import com.pushtorefresh.storio.contentresolver.queries.UpdateQuery;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Put Operation
+ */
+public class BoxedTypesPrivateFieldsIgnoreNullStorIOContentResolverPutResolver extends DefaultPutResolver<BoxedTypesPrivateFieldsIgnoreNull> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public InsertQuery mapToInsertQuery(@NonNull BoxedTypesPrivateFieldsIgnoreNull object) {
+        return InsertQuery.builder()
+                .uri("content://uri")
+                .build();}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public UpdateQuery mapToUpdateQuery(@NonNull BoxedTypesPrivateFieldsIgnoreNull object) {
+        return UpdateQuery.builder()
+                .uri("content://uri")
+                .where("field4 = ?")
+                .whereArgs(object.getField4())
+                .build();}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public ContentValues mapToContentValues(@NonNull BoxedTypesPrivateFieldsIgnoreNull object) {
+        ContentValues contentValues = new ContentValues(6);
+
+        if (object.getField1() != null) {
+            contentValues.put("field1", object.getField1());
+        }
+        if (object.getField2() != null) {
+            contentValues.put("field2", object.getField2());
+        }
+        if (object.getField3() != null) {
+            contentValues.put("field3", object.getField3());
+        }
+        if (object.getField4() != null) {
+            contentValues.put("field4", object.getField4());
+        }
+        if (object.getField5() != null) {
+            contentValues.put("field5", object.getField5());
+        }
+        if (object.getField6() != null) {
+            contentValues.put("field6", object.getField6());
+        }
+
+        return contentValues;
+    }
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsStorIOContentResolverDeleteResolver.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsStorIOContentResolverDeleteResolver.java
@@ -1,0 +1,24 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.contentresolver.operations.delete.DefaultDeleteResolver;
+import com.pushtorefresh.storio.contentresolver.queries.DeleteQuery;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Delete Operation
+ */
+public class BoxedTypesPrivateFieldsStorIOContentResolverDeleteResolver extends DefaultDeleteResolver<BoxedTypesPrivateFields> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public DeleteQuery mapToDeleteQuery(@NonNull BoxedTypesPrivateFields object) {
+        return DeleteQuery.builder()
+                .uri("content://uri")
+                .where("field4 = ?")
+                .whereArgs(object.getField4())
+                .build();}
+}
+

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsStorIOContentResolverGetResolver.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsStorIOContentResolverGetResolver.java
@@ -1,0 +1,41 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.contentresolver.operations.get.DefaultGetResolver;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Get Operation
+ */
+public class BoxedTypesPrivateFieldsStorIOContentResolverGetResolver extends DefaultGetResolver<BoxedTypesPrivateFields> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public BoxedTypesPrivateFields mapFromCursor(@NonNull Cursor cursor) {
+        BoxedTypesPrivateFields object = new BoxedTypesPrivateFields();
+
+        if (!cursor.isNull(cursor.getColumnIndex("field1"))) {
+            object.setField1(cursor.getInt(cursor.getColumnIndex("field1")) == 1);
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field2"))) {
+            object.setField2(cursor.getShort(cursor.getColumnIndex("field2")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field3"))) {
+            object.setField3(cursor.getInt(cursor.getColumnIndex("field3")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field4"))) {
+            object.setField4(cursor.getLong(cursor.getColumnIndex("field4")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field5"))) {
+            object.setField5(cursor.getFloat(cursor.getColumnIndex("field5")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field6"))) {
+            object.setField6(cursor.getDouble(cursor.getColumnIndex("field6")));
+        }
+
+        return object;
+    }
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsStorIOContentResolverPutResolver.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsStorIOContentResolverPutResolver.java
@@ -1,0 +1,53 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+import android.content.ContentValues;
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.contentresolver.operations.put.DefaultPutResolver;
+import com.pushtorefresh.storio.contentresolver.queries.InsertQuery;
+import com.pushtorefresh.storio.contentresolver.queries.UpdateQuery;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Put Operation
+ */
+public class BoxedTypesPrivateFieldsStorIOContentResolverPutResolver extends DefaultPutResolver<BoxedTypesPrivateFields> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public InsertQuery mapToInsertQuery(@NonNull BoxedTypesPrivateFields object) {
+        return InsertQuery.builder()
+                .uri("content://uri")
+                .build();}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public UpdateQuery mapToUpdateQuery(@NonNull BoxedTypesPrivateFields object) {
+        return UpdateQuery.builder()
+                .uri("content://uri")
+                .where("field4 = ?")
+                .whereArgs(object.getField4())
+                .build();}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public ContentValues mapToContentValues(@NonNull BoxedTypesPrivateFields object) {
+        ContentValues contentValues = new ContentValues(6);
+
+        contentValues.put("field1", object.getField1());
+        contentValues.put("field2", object.getField2());
+        contentValues.put("field3", object.getField3());
+        contentValues.put("field4", object.getField4());
+        contentValues.put("field5", object.getField5());
+        contentValues.put("field6", object.getField6());
+
+        return contentValues;
+    }
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/PrimitivePrivateFields.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/PrimitivePrivateFields.java
@@ -1,0 +1,93 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+@StorIOContentResolverType(uri = "content://uri")
+public class PrimitivePrivateFields {
+
+    @StorIOContentResolverColumn(name = "field1")
+    private boolean field1;
+
+    @StorIOContentResolverColumn(name = "field2")
+    private short field2;
+
+    @StorIOContentResolverColumn(name = "field3")
+    private int field3;
+
+    @StorIOContentResolverColumn(name = "field4", key = true)
+    private long field4;
+
+    @StorIOContentResolverColumn(name = "field5")
+    private float field5;
+
+    @StorIOContentResolverColumn(name = "field6")
+    private double field6;
+
+    @StorIOContentResolverColumn(name = "field7")
+    private String field7;
+
+    @StorIOContentResolverColumn(name = "field8")
+    private byte[] field8;
+
+    public boolean isField1() {
+        return field1;
+    }
+
+    public void setField1(boolean field1) {
+        this.field1 = field1;
+    }
+
+    public short getField2() {
+        return field2;
+    }
+
+    public void setField2(short field2) {
+        this.field2 = field2;
+    }
+
+    public int getField3() {
+        return field3;
+    }
+
+    public void setField3(int field3) {
+        this.field3 = field3;
+    }
+
+    public long getField4() {
+        return field4;
+    }
+
+    public void setField4(long field4) {
+        this.field4 = field4;
+    }
+
+    public float getField5() {
+        return field5;
+    }
+
+    public void setField5(float field5) {
+        this.field5 = field5;
+    }
+
+    public double getField6() {
+        return field6;
+    }
+
+    public void setField6(double field6) {
+        this.field6 = field6;
+    }
+
+    public String getField7() {
+        return field7;
+    }
+
+    public void setField7(String field7) {
+        this.field7 = field7;
+    }
+
+    public byte[] getField8() {
+        return field8;
+    }
+
+    public void setField8(byte[] field8) {
+        this.field8 = field8;
+    }
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsContentResolverTypeMapping.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsContentResolverTypeMapping.java
@@ -1,0 +1,14 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+import com.pushtorefresh.storio.contentresolver.ContentResolverTypeMapping;
+
+/**
+ * Generated mapping with collection of resolvers
+ */
+public class PrimitivePrivateFieldsContentResolverTypeMapping extends ContentResolverTypeMapping<PrimitivePrivateFields> {
+    public PrimitivePrivateFieldsContentResolverTypeMapping() {
+        super(new PrimitivePrivateFieldsStorIOContentResolverPutResolver(),
+                new PrimitivePrivateFieldsStorIOContentResolverGetResolver(),
+                new PrimitivePrivateFieldsStorIOContentResolverDeleteResolver());
+    }
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsStorIOContentResolverDeleteResolver.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsStorIOContentResolverDeleteResolver.java
@@ -1,0 +1,23 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.contentresolver.operations.delete.DefaultDeleteResolver;
+import com.pushtorefresh.storio.contentresolver.queries.DeleteQuery;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Delete Operation
+ */
+public class PrimitivePrivateFieldsStorIOContentResolverDeleteResolver extends DefaultDeleteResolver<PrimitivePrivateFields> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public DeleteQuery mapToDeleteQuery(@NonNull PrimitivePrivateFields object) {
+        return DeleteQuery.builder()
+                .uri("content://uri")
+                .where("field4 = ?")
+                .whereArgs(object.getField4())
+                .build();}
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsStorIOContentResolverGetResolver.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsStorIOContentResolverGetResolver.java
@@ -1,0 +1,31 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.contentresolver.operations.get.DefaultGetResolver;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Get Operation
+ */
+public class PrimitivePrivateFieldsStorIOContentResolverGetResolver extends DefaultGetResolver<PrimitivePrivateFields> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public PrimitivePrivateFields mapFromCursor(@NonNull Cursor cursor) {
+        PrimitivePrivateFields object = new PrimitivePrivateFields();
+
+        object.setField1(cursor.getInt(cursor.getColumnIndex("field1")) == 1);
+        object.setField2(cursor.getShort(cursor.getColumnIndex("field2")));
+        object.setField3(cursor.getInt(cursor.getColumnIndex("field3")));
+        object.setField4(cursor.getLong(cursor.getColumnIndex("field4")));
+        object.setField5(cursor.getFloat(cursor.getColumnIndex("field5")));
+        object.setField6(cursor.getDouble(cursor.getColumnIndex("field6")));
+        object.setField7(cursor.getString(cursor.getColumnIndex("field7")));
+        object.setField8(cursor.getBlob(cursor.getColumnIndex("field8")));
+
+        return object;
+    }
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsStorIOContentResolverPutResolver.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsStorIOContentResolverPutResolver.java
@@ -1,0 +1,55 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+import android.content.ContentValues;
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.contentresolver.operations.put.DefaultPutResolver;
+import com.pushtorefresh.storio.contentresolver.queries.InsertQuery;
+import com.pushtorefresh.storio.contentresolver.queries.UpdateQuery;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Put Operation
+ */
+public class PrimitivePrivateFieldsStorIOContentResolverPutResolver extends DefaultPutResolver<PrimitivePrivateFields> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public InsertQuery mapToInsertQuery(@NonNull PrimitivePrivateFields object) {
+        return InsertQuery.builder()
+                .uri("content://uri")
+                .build();}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public UpdateQuery mapToUpdateQuery(@NonNull PrimitivePrivateFields object) {
+        return UpdateQuery.builder()
+                .uri("content://uri")
+                .where("field4 = ?")
+                .whereArgs(object.getField4())
+                .build();}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public ContentValues mapToContentValues(@NonNull PrimitivePrivateFields object) {
+        ContentValues contentValues = new ContentValues(8);
+
+        contentValues.put("field1", object.isField1());
+        contentValues.put("field2", object.getField2());
+        contentValues.put("field3", object.getField3());
+        contentValues.put("field4", object.getField4());
+        contentValues.put("field5", object.getField5());
+        contentValues.put("field6", object.getField6());
+        contentValues.put("field7", object.getField7());
+        contentValues.put("field8", object.getField8());
+
+        return contentValues;
+    }
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/PrivateFieldWithIsGetter.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/PrivateFieldWithIsGetter.java
@@ -1,0 +1,27 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+@StorIOContentResolverType(uri = "content://uri")
+public class PrivateFieldWithIsGetter {
+
+    @StorIOContentResolverColumn(name = "id", key = true)
+    private long id;
+
+    @StorIOContentResolverColumn(name = "flag")
+    private boolean flag;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public boolean isFlag() {
+        return flag;
+    }
+
+    public void setFlag(boolean flag) {
+        this.flag = flag;
+    }
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/PrivateFieldWithNameStartingWithIs.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/PrivateFieldWithNameStartingWithIs.java
@@ -1,12 +1,12 @@
-package com.pushtorefresh.storio.sqlite.annotations;
+package com.pushtorefresh.storio.contentresolver.annotations;
 
-@StorIOSQLiteType(table = "table")
-public class PrivateFieldWithIsCornerCase {
+@StorIOContentResolverType(uri = "content://uri")
+public class PrivateFieldWithNameStartingWithIs {
 
-    @StorIOSQLiteColumn(name = "id", key = true)
+    @StorIOContentResolverColumn(name = "id", key = true)
     private long id;
 
-    @StorIOSQLiteColumn(name = "is_flag")
+    @StorIOContentResolverColumn(name = "is_flag")
     private boolean isFlag;
 
     public long getId() {

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/PrivateFieldWithoutAccessors.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/PrivateFieldWithoutAccessors.java
@@ -1,0 +1,8 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+@StorIOContentResolverType(uri = "content://uri")
+public class PrivateFieldWithoutAccessors {
+
+    @StorIOContentResolverColumn(name = "id", key = true)
+    private long id;
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/PrivateFieldWithoutGetter.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/PrivateFieldWithoutGetter.java
@@ -1,8 +1,12 @@
 package com.pushtorefresh.storio.contentresolver.annotations;
 
 @StorIOContentResolverType(uri = "content://uri")
-public class PrivateField {
+public class PrivateFieldWithoutGetter {
 
     @StorIOContentResolverColumn(name = "id", key = true)
     private long id;
+
+    public void setId(long id) {
+        this.id = id;
+    }
 }

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/PrivateFieldWithoutSetter.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/PrivateFieldWithoutSetter.java
@@ -1,0 +1,12 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+@StorIOContentResolverType(uri = "content://uri")
+public class PrivateFieldWithoutSetter {
+
+    @StorIOContentResolverColumn(name = "id", key = true)
+    private long id;
+
+    public long getId() {
+        return id;
+    }
+}

--- a/storio-content-resolver-annotations-processor-test/src/test/resources/PrivateMethod.java
+++ b/storio-content-resolver-annotations-processor-test/src/test/resources/PrivateMethod.java
@@ -1,0 +1,10 @@
+package com.pushtorefresh.storio.contentresolver.annotations;
+
+@StorIOContentResolverType(uri = "content://uri")
+public class PrivateMethod {
+
+    @StorIOContentResolverColumn(name = "id", key = true)
+    private long id() {
+        return 0;
+    }
+}

--- a/storio-content-resolver-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/contentresolver/annotations/processor/StorIOContentResolverProcessor.kt
+++ b/storio-content-resolver-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/contentresolver/annotations/processor/StorIOContentResolverProcessor.kt
@@ -16,10 +16,7 @@ import com.pushtorefresh.storio.contentresolver.annotations.processor.introspect
 import com.pushtorefresh.storio.contentresolver.annotations.processor.introspection.StorIOContentResolverCreatorMeta
 import com.pushtorefresh.storio.contentresolver.annotations.processor.introspection.StorIOContentResolverTypeMeta
 import javax.annotation.processing.RoundEnvironment
-import javax.lang.model.element.Element
-import javax.lang.model.element.ElementKind
-import javax.lang.model.element.ExecutableElement
-import javax.lang.model.element.TypeElement
+import javax.lang.model.element.*
 import javax.lang.model.util.Elements
 import javax.tools.Diagnostic.Kind.WARNING
 
@@ -170,6 +167,13 @@ open class StorIOContentResolverProcessor : StorIOAnnotationsProcessor<StorIOCon
 
         if (column.name.isEmpty()) {
             throw ProcessingException(annotatedField, "Column name is empty: ${annotatedField.simpleName}")
+        }
+
+        if (Modifier.PRIVATE in annotatedField.modifiers) {
+            // can't be null since we validated it before
+            val (getter, setter) = accessorsMap[annotatedField.simpleName.toString()]!!
+
+            return StorIOContentResolverColumnMeta(annotatedField.enclosingElement, annotatedField, annotatedField.simpleName.toString(), javaType, column, getter, setter)
         }
 
         return StorIOContentResolverColumnMeta(annotatedField.enclosingElement, annotatedField, annotatedField.simpleName.toString(), javaType, column)

--- a/storio-content-resolver-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/GetResolverGenerator.kt
+++ b/storio-content-resolver-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/GetResolverGenerator.kt
@@ -58,7 +58,11 @@ object GetResolverGenerator : Generator<StorIOContentResolverTypeMeta> {
             // otherwise -> if primitive and value from cursor null -> fail early
             if (isBoxed) builder.beginControlFlow("if (!cursor.isNull(\$L))", columnIndex)
 
-            builder.addStatement("object.\$L = cursor.\$L", columnMeta.elementName, getFromCursor)
+            if (columnMeta.needAccessors) {
+                builder.addStatement("object.\$L(cursor.\$L)", columnMeta.setter, getFromCursor)
+            } else {
+                builder.addStatement("object.\$L = cursor.\$L", columnMeta.elementName, getFromCursor)
+            }
 
             if (isBoxed) builder.endControlFlow()
         }

--- a/storio-content-resolver-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/PutResolverGenerator.kt
+++ b/storio-content-resolver-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/PutResolverGenerator.kt
@@ -67,11 +67,11 @@ object PutResolverGenerator : Generator<StorIOContentResolverTypeMeta> {
                         .addAnnotation(ANDROID_NON_NULL_ANNOTATION_CLASS_NAME)
                         .build())
                 .addCode("""return UpdateQuery.builder()
-$INDENT.uri(${"$"}S)
-$INDENT.where(${"$"}S)
-$INDENT.whereArgs(${"$"}L)
-$INDENT.build();
-""",
+                            $INDENT.uri(${"$"}S)
+                            $INDENT.where(${"$"}S)
+                            $INDENT.whereArgs(${"$"}L)
+                            $INDENT.build();
+                         """.trimIndent(),
                         updateUri,
                         where[QueryGenerator.WHERE_CLAUSE],
                         where[QueryGenerator.WHERE_ARGS])
@@ -88,19 +88,15 @@ $INDENT.build();
                 .addParameter(ParameterSpec.builder(className, "object")
                         .addAnnotation(ANDROID_NON_NULL_ANNOTATION_CLASS_NAME)
                         .build())
-                .addStatement("ContentValues contentValues = new ContentValues(\$L)",
-                        typeMeta
-                                .columns.size)
+                .addStatement("ContentValues contentValues = new ContentValues(\$L)", typeMeta.columns.size)
                 .addCode("\n")
 
-        for (columnMeta in typeMeta
-                .columns.values) {
+        typeMeta.columns.values.forEach { columnMeta ->
             val ignoreNull = columnMeta.storIOColumn.ignoreNull
             if (ignoreNull) {
-                builder.beginControlFlow("if (object.\$L != null)", "${columnMeta.elementName}${if (columnMeta.isMethod) "()" else ""}")
+                builder.beginControlFlow("if (object.\$L != null)", columnMeta.contextAwareName)
             }
-            builder.addStatement("contentValues.put(\$S, object.\$L)", columnMeta.storIOColumn.name, "${columnMeta.elementName}${if (columnMeta.isMethod) "()" else ""}"
-            )
+            builder.addStatement("contentValues.put(\$S, object.\$L)", columnMeta.storIOColumn.name, columnMeta.contextAwareName)
             if (ignoreNull) builder.endControlFlow()
         }
 

--- a/storio-content-resolver-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/QueryGenerator.kt
+++ b/storio-content-resolver-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/contentresolver/annotations/processor/generate/QueryGenerator.kt
@@ -23,7 +23,7 @@ object QueryGenerator {
                     whereArgs
                             .append(varName)
                             .append(".")
-                            .append(columnMeta.elementName)
+                            .append(columnMeta.contextAwareName)
                 } else {
                     whereClause
                             .append(" AND ")
@@ -34,11 +34,8 @@ object QueryGenerator {
                             .append(", ")
                             .append(varName)
                             .append(".")
-                            .append(columnMeta.elementName)
+                            .append(columnMeta.contextAwareName)
                 }
-
-                if (columnMeta.isMethod) whereArgs.append("()")
-
                 i++
             }
         }

--- a/storio-content-resolver-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/contentresolver/annotations/processor/introspection/StorIOContentResolverColumnMeta.kt
+++ b/storio-content-resolver-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/contentresolver/annotations/processor/introspection/StorIOContentResolverColumnMeta.kt
@@ -11,10 +11,14 @@ class StorIOContentResolverColumnMeta(
         element: Element,
         fieldName: String,
         javaType: JavaType,
-        storIOColumn: StorIOContentResolverColumn)
+        storIOColumn: StorIOContentResolverColumn,
+        getter: String? = null,
+        setter: String? = null)
     : StorIOColumnMeta<StorIOContentResolverColumn>(
         enclosingElement,
         element,
         fieldName,
         javaType,
-        storIOColumn)
+        storIOColumn,
+        getter,
+        setter)

--- a/storio-sqlite-annotations-processor-test/src/test/java/com/pushtorefresh/storio/sqlite/annotations/processor/test/StorIOSQLiteAnnotationsProcessorTest.java
+++ b/storio-sqlite-annotations-processor-test/src/test/java/com/pushtorefresh/storio/sqlite/annotations/processor/test/StorIOSQLiteAnnotationsProcessorTest.java
@@ -509,7 +509,7 @@ public class StorIOSQLiteAnnotationsProcessorTest {
 
     @Test
     public void shouldCompileIfAnnotatedFieldIsPrivateAndHasNameStartingWithIs() {
-        JavaFileObject model = JavaFileObjects.forResource("PrivateFieldWithIsCornerCase.java");
+        JavaFileObject model = JavaFileObjects.forResource("PrivateFieldWithNameStartingWithIs.java");
 
         assert_().about(javaSource())
                 .that(model)
@@ -552,7 +552,7 @@ public class StorIOSQLiteAnnotationsProcessorTest {
     }
 
     @Test
-    public void shouldCompileWithPrivateBoxedTypesFieldsWithCorrespondingAccessprsAndMarkedAsIgnoreNull() {
+    public void shouldCompileWithPrivateBoxedTypesFieldsWithCorrespondingAccessorsAndMarkedAsIgnoreNull() {
         JavaFileObject model = JavaFileObjects.forResource("BoxedTypesPrivateFieldsIgnoreNull.java");
 
         JavaFileObject generatedTypeMapping = JavaFileObjects.forResource("BoxedTypesPrivateFieldsIgnoreNullSQLiteTypeMapping.java");

--- a/storio-sqlite-annotations-processor-test/src/test/java/com/pushtorefresh/storio/sqlite/annotations/processor/test/StorIOSQLiteAnnotationsProcessorTest.java
+++ b/storio-sqlite-annotations-processor-test/src/test/java/com/pushtorefresh/storio/sqlite/annotations/processor/test/StorIOSQLiteAnnotationsProcessorTest.java
@@ -72,7 +72,7 @@ public class StorIOSQLiteAnnotationsProcessorTest {
 
     @Test
     public void shouldNotCompileIfAnnotatedFieldIsPrivateAndDoesNotHaveAccessors() {
-        JavaFileObject model = JavaFileObjects.forResource("PrivateField.java");
+        JavaFileObject model = JavaFileObjects.forResource("PrivateFieldWithoutAccessors.java");
 
         assert_().about(javaSource())
                 .that(model)
@@ -476,13 +476,95 @@ public class StorIOSQLiteAnnotationsProcessorTest {
     }
 
     @Test
-    public void shouldCompileWithPrivateFieldWithCorrespondingAccessors() {
-        JavaFileObject model = JavaFileObjects.forResource("PrivateFieldWithCorrespondingAccessors.java");
+    public void shouldNotCompileIfAnnotatedFieldIsPrivateAndDoesNotHaveSetter() {
+        JavaFileObject model = JavaFileObjects.forResource("PrivateFieldWithoutSetter.java");
 
         assert_().about(javaSource())
-            .that(model)
-            .processedWith(new StorIOSQLiteProcessor())
-            .compilesWithoutError();
+                .that(model)
+                .processedWith(new StorIOSQLiteProcessor())
+                .failsToCompile()
+                .withErrorContaining("StorIOSQLiteColumn can not be applied to private field without corresponding getter and setter or private method: id");
     }
 
+    @Test
+    public void shouldNotCompileIfAnnotatedFieldIsPrivateAndDoesNotHaveGetter() {
+        JavaFileObject model = JavaFileObjects.forResource("PrivateFieldWithoutGetter.java");
+
+        assert_().about(javaSource())
+                .that(model)
+                .processedWith(new StorIOSQLiteProcessor())
+                .failsToCompile()
+                .withErrorContaining("StorIOSQLiteColumn can not be applied to private field without corresponding getter and setter or private method: id");
+    }
+
+    @Test
+    public void shouldCompileIfAnnotatedFieldIsPrivateAndHasIsGetter() {
+        JavaFileObject model = JavaFileObjects.forResource("PrivateFieldWithIsGetter.java");
+
+        assert_().about(javaSource())
+                .that(model)
+                .processedWith(new StorIOSQLiteProcessor())
+                .compilesWithoutError();
+    }
+
+    @Test
+    public void shouldCompileIfAnnotatedFieldIsPrivateAndHasNameStartingWithIs() {
+        JavaFileObject model = JavaFileObjects.forResource("PrivateFieldWithIsCornerCase.java");
+
+        assert_().about(javaSource())
+                .that(model)
+                .processedWith(new StorIOSQLiteProcessor())
+                .compilesWithoutError();
+    }
+
+    @Test
+    public void shouldCompileWithPrivatePrimitiveFieldsWithCorrespondingAccessors() {
+        JavaFileObject model = JavaFileObjects.forResource("PrimitivePrivateFields.java");
+
+        JavaFileObject generatedTypeMapping = JavaFileObjects.forResource("PrimitivePrivateFieldsSQLiteTypeMapping.java");
+        JavaFileObject generatedDeleteResolver = JavaFileObjects.forResource("PrimitivePrivateFieldsStorIOSQLiteDeleteResolver.java");
+        JavaFileObject generatedGetResolver = JavaFileObjects.forResource("PrimitivePrivateFieldsStorIOSQLiteGetResolver.java");
+        JavaFileObject generatedPutResolver = JavaFileObjects.forResource("PrimitivePrivateFieldsStorIOSQLitePutResolver.java");
+
+        assert_().about(javaSource())
+                .that(model)
+                .processedWith(new StorIOSQLiteProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(generatedTypeMapping, generatedDeleteResolver, generatedGetResolver, generatedPutResolver);
+    }
+
+    @Test
+    public void shouldCompileWithPrivateBoxedTypesFieldsWithCorrespondingAccessors() {
+        JavaFileObject model = JavaFileObjects.forResource("BoxedTypesPrivateFields.java");
+
+        JavaFileObject generatedTypeMapping = JavaFileObjects.forResource("BoxedTypesPrivateFieldsSQLiteTypeMapping.java");
+        JavaFileObject generatedDeleteResolver = JavaFileObjects.forResource("BoxedTypesPrivateFieldsStorIOSQLiteDeleteResolver.java");
+        JavaFileObject generatedGetResolver = JavaFileObjects.forResource("BoxedTypesPrivateFieldsStorIOSQLiteGetResolver.java");
+        JavaFileObject generatedPutResolver = JavaFileObjects.forResource("BoxedTypesPrivateFieldsStorIOSQLitePutResolver.java");
+
+        assert_().about(javaSource())
+                .that(model)
+                .processedWith(new StorIOSQLiteProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(generatedTypeMapping, generatedDeleteResolver, generatedGetResolver, generatedPutResolver);
+    }
+
+    @Test
+    public void shouldCompileWithPrivateBoxedTypesFieldsWithCorrespondingAccessprsAndMarkedAsIgnoreNull() {
+        JavaFileObject model = JavaFileObjects.forResource("BoxedTypesPrivateFieldsIgnoreNull.java");
+
+        JavaFileObject generatedTypeMapping = JavaFileObjects.forResource("BoxedTypesPrivateFieldsIgnoreNullSQLiteTypeMapping.java");
+        JavaFileObject generatedDeleteResolver = JavaFileObjects.forResource("BoxedTypesPrivateFieldsIgnoreNullStorIOSQLiteDeleteResolver.java");
+        JavaFileObject generatedGetResolver = JavaFileObjects.forResource("BoxedTypesPrivateFieldsIgnoreNullStorIOSQLiteGetResolver.java");
+        JavaFileObject generatedPutResolver = JavaFileObjects.forResource("BoxedTypesPrivateFieldsIgnoreNullStorIOSQLitePutResolver.java");
+
+        assert_().about(javaSource())
+                .that(model)
+                .processedWith(new StorIOSQLiteProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(generatedTypeMapping, generatedDeleteResolver, generatedGetResolver, generatedPutResolver);
+    }
 }

--- a/storio-sqlite-annotations-processor-test/src/test/java/com/pushtorefresh/storio/sqlite/annotations/processor/test/StorIOSQLiteAnnotationsProcessorTest.java
+++ b/storio-sqlite-annotations-processor-test/src/test/java/com/pushtorefresh/storio/sqlite/annotations/processor/test/StorIOSQLiteAnnotationsProcessorTest.java
@@ -71,14 +71,25 @@ public class StorIOSQLiteAnnotationsProcessorTest {
     }
 
     @Test
-    public void shouldNotCompileIfAnnotatedFieldIsPrivate() {
+    public void shouldNotCompileIfAnnotatedFieldIsPrivateAndDoesNotHaveAccessors() {
         JavaFileObject model = JavaFileObjects.forResource("PrivateField.java");
 
         assert_().about(javaSource())
                 .that(model)
                 .processedWith(new StorIOSQLiteProcessor())
                 .failsToCompile()
-                .withErrorContaining("StorIOSQLiteColumn can not be applied to private field or method: id");
+                .withErrorContaining("StorIOSQLiteColumn can not be applied to private field without corresponding getter and setter or private method: id");
+    }
+
+    @Test
+    public void shouldNotCompileIfAnnotatedMethodIsPrivate() {
+        JavaFileObject model = JavaFileObjects.forResource("PrivateMethod.java");
+
+        assert_().about(javaSource())
+            .that(model)
+            .processedWith(new StorIOSQLiteProcessor())
+            .failsToCompile()
+            .withErrorContaining("StorIOSQLiteColumn can not be applied to private field without corresponding getter and setter or private method: id");
     }
 
     @Test
@@ -397,8 +408,7 @@ public class StorIOSQLiteAnnotationsProcessorTest {
     }
 
     @Test
-    public void
-    shouldCompileWithMethodsReturningBoxedTypesAndMarkedAsIgnoreNullAndConstructorAsCreator() {
+    public void shouldCompileWithMethodsReturningBoxedTypesAndMarkedAsIgnoreNullAndConstructorAsCreator() {
         JavaFileObject model = JavaFileObjects.forResource("BoxedTypesMethodsConstructorIgnoreNull.java");
 
         JavaFileObject generatedTypeMapping = JavaFileObjects.forResource("BoxedTypesMethodsConstructorIgnoreNullSQLiteTypeMapping.java");
@@ -449,8 +459,7 @@ public class StorIOSQLiteAnnotationsProcessorTest {
     }
 
     @Test
-    public void
-    shouldCompileWithMethodsReturningBoxedTypesAndMarkedAsIgnoreNullAndFactoryMethodAsCreator() {
+    public void shouldCompileWithMethodsReturningBoxedTypesAndMarkedAsIgnoreNullAndFactoryMethodAsCreator() {
         JavaFileObject model = JavaFileObjects.forResource("BoxedTypesMethodsFactoryMethodIgnoreNull.java");
 
         JavaFileObject generatedTypeMapping = JavaFileObjects.forResource("BoxedTypesMethodsFactoryMethodIgnoreNullSQLiteTypeMapping.java");
@@ -464,6 +473,16 @@ public class StorIOSQLiteAnnotationsProcessorTest {
                 .compilesWithoutError()
                 .and()
                 .generatesSources(generatedTypeMapping, generatedDeleteResolver, generatedGetResolver, generatedPutResolver);
+    }
+
+    @Test
+    public void shouldCompileWithPrivateFieldWithCorrespondingAccessors() {
+        JavaFileObject model = JavaFileObjects.forResource("PrivateFieldWithCorrespondingAccessors.java");
+
+        assert_().about(javaSource())
+            .that(model)
+            .processedWith(new StorIOSQLiteProcessor())
+            .compilesWithoutError();
     }
 
 }

--- a/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFields.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFields.java
@@ -1,0 +1,71 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+@StorIOSQLiteType(table = "table")
+public class BoxedTypesPrivateFields {
+
+    @StorIOSQLiteColumn(name = "field1")
+    private Boolean field1;
+
+    @StorIOSQLiteColumn(name = "field2")
+    private Short field2;
+
+    @StorIOSQLiteColumn(name = "field3")
+    private Integer field3;
+
+    @StorIOSQLiteColumn(name = "field4", key = true)
+    private Long field4;
+
+    @StorIOSQLiteColumn(name = "field5")
+    private Float field5;
+
+    @StorIOSQLiteColumn(name = "field6")
+    private Double field6;
+
+    public Boolean getField1() {
+        return field1;
+    }
+
+    public void setField1(Boolean field1) {
+        this.field1 = field1;
+    }
+
+    public Short getField2() {
+        return field2;
+    }
+
+    public void setField2(Short field2) {
+        this.field2 = field2;
+    }
+
+    public Integer getField3() {
+        return field3;
+    }
+
+    public void setField3(Integer field3) {
+        this.field3 = field3;
+    }
+
+    public Long getField4() {
+        return field4;
+    }
+
+    public void setField4(Long field4) {
+        this.field4 = field4;
+    }
+
+    public Float getField5() {
+        return field5;
+    }
+
+    public void setField5(Float field5) {
+        this.field5 = field5;
+    }
+
+    public Double getField6() {
+        return field6;
+    }
+
+    public void setField6(Double field6) {
+        this.field6 = field6;
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNull.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNull.java
@@ -1,0 +1,71 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+@StorIOSQLiteType(table = "table")
+public class BoxedTypesPrivateFieldsIgnoreNull {
+
+    @StorIOSQLiteColumn(name = "field1", ignoreNull = true)
+    private Boolean field1;
+
+    @StorIOSQLiteColumn(name = "field2", ignoreNull = true)
+    private Short field2;
+
+    @StorIOSQLiteColumn(name = "field3", ignoreNull = true)
+    private Integer field3;
+
+    @StorIOSQLiteColumn(name = "field4", key = true, ignoreNull = true)
+    private Long field4;
+
+    @StorIOSQLiteColumn(name = "field5", ignoreNull = true)
+    private Float field5;
+
+    @StorIOSQLiteColumn(name = "field6", ignoreNull = true)
+    private Double field6;
+
+    public Boolean getField1() {
+        return field1;
+    }
+
+    public void setField1(Boolean field1) {
+        this.field1 = field1;
+    }
+
+    public Short getField2() {
+        return field2;
+    }
+
+    public void setField2(Short field2) {
+        this.field2 = field2;
+    }
+
+    public Integer getField3() {
+        return field3;
+    }
+
+    public void setField3(Integer field3) {
+        this.field3 = field3;
+    }
+
+    public Long getField4() {
+        return field4;
+    }
+
+    public void setField4(Long field4) {
+        this.field4 = field4;
+    }
+
+    public Float getField5() {
+        return field5;
+    }
+
+    public void setField5(Float field5) {
+        this.field5 = field5;
+    }
+
+    public Double getField6() {
+        return field6;
+    }
+
+    public void setField6(Double field6) {
+        this.field6 = field6;
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullSQLiteTypeMapping.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullSQLiteTypeMapping.java
@@ -1,0 +1,14 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+import com.pushtorefresh.storio.sqlite.SQLiteTypeMapping;
+
+/**
+ * Generated mapping with collection of resolvers.
+ */
+public class BoxedTypesPrivateFieldsIgnoreNullSQLiteTypeMapping extends SQLiteTypeMapping<BoxedTypesPrivateFieldsIgnoreNull> {
+    public BoxedTypesPrivateFieldsIgnoreNullSQLiteTypeMapping() {
+        super(new BoxedTypesPrivateFieldsIgnoreNullStorIOSQLitePutResolver(),
+                new BoxedTypesPrivateFieldsIgnoreNullStorIOSQLiteGetResolver(),
+                new BoxedTypesPrivateFieldsIgnoreNullStorIOSQLiteDeleteResolver());
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullStorIOSQLiteDeleteResolver.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullStorIOSQLiteDeleteResolver.java
@@ -1,0 +1,23 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.sqlite.operations.delete.DefaultDeleteResolver;
+import com.pushtorefresh.storio.sqlite.queries.DeleteQuery;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Delete Operation.
+ */
+public class BoxedTypesPrivateFieldsIgnoreNullStorIOSQLiteDeleteResolver extends DefaultDeleteResolver<BoxedTypesPrivateFieldsIgnoreNull> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public DeleteQuery mapToDeleteQuery(@NonNull BoxedTypesPrivateFieldsIgnoreNull object) {
+        return DeleteQuery.builder()
+                .table("table")
+                .where("field4 = ?")
+                .whereArgs(object.getField4())
+                .build();}
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullStorIOSQLiteGetResolver.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullStorIOSQLiteGetResolver.java
@@ -1,0 +1,41 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.sqlite.operations.get.DefaultGetResolver;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Get Operation.
+ */
+public class BoxedTypesPrivateFieldsIgnoreNullStorIOSQLiteGetResolver extends DefaultGetResolver<BoxedTypesPrivateFieldsIgnoreNull> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public BoxedTypesPrivateFieldsIgnoreNull mapFromCursor(@NonNull Cursor cursor) {
+        BoxedTypesPrivateFieldsIgnoreNull object = new BoxedTypesPrivateFieldsIgnoreNull();
+
+        if (!cursor.isNull(cursor.getColumnIndex("field1"))) {
+            object.setField1(cursor.getInt(cursor.getColumnIndex("field1")) == 1);
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field2"))) {
+            object.setField2(cursor.getShort(cursor.getColumnIndex("field2")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field3"))) {
+            object.setField3(cursor.getInt(cursor.getColumnIndex("field3")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field4"))) {
+            object.setField4(cursor.getLong(cursor.getColumnIndex("field4")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field5"))) {
+            object.setField5(cursor.getFloat(cursor.getColumnIndex("field5")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field6"))) {
+            object.setField6(cursor.getDouble(cursor.getColumnIndex("field6")));
+        }
+
+        return object;
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullStorIOSQLitePutResolver.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsIgnoreNullStorIOSQLitePutResolver.java
@@ -1,0 +1,66 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+import android.content.ContentValues;
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.sqlite.operations.put.DefaultPutResolver;
+import com.pushtorefresh.storio.sqlite.queries.InsertQuery;
+import com.pushtorefresh.storio.sqlite.queries.UpdateQuery;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Put Operation.
+ */
+public class BoxedTypesPrivateFieldsIgnoreNullStorIOSQLitePutResolver extends DefaultPutResolver<BoxedTypesPrivateFieldsIgnoreNull> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public InsertQuery mapToInsertQuery(@NonNull BoxedTypesPrivateFieldsIgnoreNull object) {
+        return InsertQuery.builder()
+                .table("table")
+                .build();}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public UpdateQuery mapToUpdateQuery(@NonNull BoxedTypesPrivateFieldsIgnoreNull object) {
+        return UpdateQuery.builder()
+                .table("table")
+                .where("field4 = ?")
+                .whereArgs(object.getField4())
+                .build();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public ContentValues mapToContentValues(@NonNull BoxedTypesPrivateFieldsIgnoreNull object) {
+        ContentValues contentValues = new ContentValues(6);
+
+        if (object.getField1() != null) {
+            contentValues.put("field1", object.getField1());
+        }
+        if (object.getField2() != null) {
+            contentValues.put("field2", object.getField2());
+        }
+        if (object.getField3() != null) {
+            contentValues.put("field3", object.getField3());
+        }
+        if (object.getField4() != null) {
+            contentValues.put("field4", object.getField4());
+        }
+        if (object.getField5() != null) {
+            contentValues.put("field5", object.getField5());
+        }
+        if (object.getField6() != null) {
+            contentValues.put("field6", object.getField6());
+        }
+
+        return contentValues;
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsSQLiteTypeMapping.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsSQLiteTypeMapping.java
@@ -1,0 +1,14 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+import com.pushtorefresh.storio.sqlite.SQLiteTypeMapping;
+
+/**
+ * Generated mapping with collection of resolvers.
+ */
+public class BoxedTypesPrivateFieldsSQLiteTypeMapping extends SQLiteTypeMapping<BoxedTypesPrivateFields> {
+    public BoxedTypesPrivateFieldsSQLiteTypeMapping() {
+        super(new BoxedTypesPrivateFieldsStorIOSQLitePutResolver(),
+                new BoxedTypesPrivateFieldsStorIOSQLiteGetResolver(),
+                new BoxedTypesPrivateFieldsStorIOSQLiteDeleteResolver());
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsStorIOSQLiteDeleteResolver.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsStorIOSQLiteDeleteResolver.java
@@ -1,0 +1,24 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.sqlite.operations.delete.DefaultDeleteResolver;
+import com.pushtorefresh.storio.sqlite.queries.DeleteQuery;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Delete Operation.
+ */
+public class BoxedTypesPrivateFieldsStorIOSQLiteDeleteResolver extends DefaultDeleteResolver<BoxedTypesPrivateFields> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public DeleteQuery mapToDeleteQuery(@NonNull BoxedTypesPrivateFields object) {
+        return DeleteQuery.builder()
+                .table("table")
+                .where("field4 = ?")
+                .whereArgs(object.getField4())
+                .build();}
+}
+

--- a/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsStorIOSQLiteGetResolver.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsStorIOSQLiteGetResolver.java
@@ -1,0 +1,41 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.sqlite.operations.get.DefaultGetResolver;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Get Operation.
+ */
+public class BoxedTypesPrivateFieldsStorIOSQLiteGetResolver extends DefaultGetResolver<BoxedTypesPrivateFields> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public BoxedTypesPrivateFields mapFromCursor(@NonNull Cursor cursor) {
+        BoxedTypesPrivateFields object = new BoxedTypesPrivateFields();
+
+        if (!cursor.isNull(cursor.getColumnIndex("field1"))) {
+            object.setField1(cursor.getInt(cursor.getColumnIndex("field1")) == 1);
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field2"))) {
+            object.setField2(cursor.getShort(cursor.getColumnIndex("field2")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field3"))) {
+            object.setField3(cursor.getInt(cursor.getColumnIndex("field3")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field4"))) {
+            object.setField4(cursor.getLong(cursor.getColumnIndex("field4")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field5"))) {
+            object.setField5(cursor.getFloat(cursor.getColumnIndex("field5")));
+        }
+        if (!cursor.isNull(cursor.getColumnIndex("field6"))) {
+            object.setField6(cursor.getDouble(cursor.getColumnIndex("field6")));
+        }
+
+        return object;
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsStorIOSQLitePutResolver.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/BoxedTypesPrivateFieldsStorIOSQLitePutResolver.java
@@ -1,0 +1,54 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+import android.content.ContentValues;
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.sqlite.operations.put.DefaultPutResolver;
+import com.pushtorefresh.storio.sqlite.queries.InsertQuery;
+import com.pushtorefresh.storio.sqlite.queries.UpdateQuery;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Put Operation.
+ */
+public class BoxedTypesPrivateFieldsStorIOSQLitePutResolver extends DefaultPutResolver<BoxedTypesPrivateFields> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public InsertQuery mapToInsertQuery(@NonNull BoxedTypesPrivateFields object) {
+        return InsertQuery.builder()
+                .table("table")
+                .build();}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public UpdateQuery mapToUpdateQuery(@NonNull BoxedTypesPrivateFields object) {
+        return UpdateQuery.builder()
+                .table("table")
+                .where("field4 = ?")
+                .whereArgs(object.getField4())
+                .build();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public ContentValues mapToContentValues(@NonNull BoxedTypesPrivateFields object) {
+        ContentValues contentValues = new ContentValues(6);
+
+        contentValues.put("field1", object.getField1());
+        contentValues.put("field2", object.getField2());
+        contentValues.put("field3", object.getField3());
+        contentValues.put("field4", object.getField4());
+        contentValues.put("field5", object.getField5());
+        contentValues.put("field6", object.getField6());
+
+        return contentValues;
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/PrimitivePrivateFields.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/PrimitivePrivateFields.java
@@ -1,0 +1,93 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+@StorIOSQLiteType(table = "table")
+public class PrimitivePrivateFields {
+
+    @StorIOSQLiteColumn(name = "field1")
+    private boolean field1;
+
+    @StorIOSQLiteColumn(name = "field2")
+    private short field2;
+
+    @StorIOSQLiteColumn(name = "field3")
+    private int field3;
+
+    @StorIOSQLiteColumn(name = "field4", key = true)
+    private long field4;
+
+    @StorIOSQLiteColumn(name = "field5")
+    private float field5;
+
+    @StorIOSQLiteColumn(name = "field6")
+    private double field6;
+
+    @StorIOSQLiteColumn(name = "field7")
+    private String field7;
+
+    @StorIOSQLiteColumn(name = "field8")
+    private byte[] field8;
+
+    public boolean isField1() {
+        return field1;
+    }
+
+    public void setField1(boolean field1) {
+        this.field1 = field1;
+    }
+
+    public short getField2() {
+        return field2;
+    }
+
+    public void setField2(short field2) {
+        this.field2 = field2;
+    }
+
+    public int getField3() {
+        return field3;
+    }
+
+    public void setField3(int field3) {
+        this.field3 = field3;
+    }
+
+    public long getField4() {
+        return field4;
+    }
+
+    public void setField4(long field4) {
+        this.field4 = field4;
+    }
+
+    public float getField5() {
+        return field5;
+    }
+
+    public void setField5(float field5) {
+        this.field5 = field5;
+    }
+
+    public double getField6() {
+        return field6;
+    }
+
+    public void setField6(double field6) {
+        this.field6 = field6;
+    }
+
+    public String getField7() {
+        return field7;
+    }
+
+    public void setField7(String field7) {
+        this.field7 = field7;
+    }
+
+    public byte[] getField8() {
+        return field8;
+    }
+
+    public void setField8(byte[] field8) {
+        this.field8 = field8;
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsSQLiteTypeMapping.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsSQLiteTypeMapping.java
@@ -1,0 +1,14 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+import com.pushtorefresh.storio.sqlite.SQLiteTypeMapping;
+
+/**
+ * Generated mapping with collection of resolvers.
+ */
+public class PrimitivePrivateFieldsSQLiteTypeMapping extends SQLiteTypeMapping<PrimitivePrivateFields> {
+    public PrimitivePrivateFieldsSQLiteTypeMapping() {
+        super(new PrimitivePrivateFieldsStorIOSQLitePutResolver(),
+                new PrimitivePrivateFieldsStorIOSQLiteGetResolver(),
+                new PrimitivePrivateFieldsStorIOSQLiteDeleteResolver());
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsStorIOSQLiteDeleteResolver.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsStorIOSQLiteDeleteResolver.java
@@ -1,0 +1,23 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.sqlite.operations.delete.DefaultDeleteResolver;
+import com.pushtorefresh.storio.sqlite.queries.DeleteQuery;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Delete Operation.
+ */
+public class PrimitivePrivateFieldsStorIOSQLiteDeleteResolver extends DefaultDeleteResolver<PrimitivePrivateFields> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public DeleteQuery mapToDeleteQuery(@NonNull PrimitivePrivateFields object) {
+        return DeleteQuery.builder()
+                .table("table")
+                .where("field4 = ?")
+                .whereArgs(object.getField4())
+                .build();}
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsStorIOSQLiteGetResolver.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsStorIOSQLiteGetResolver.java
@@ -1,0 +1,31 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.sqlite.operations.get.DefaultGetResolver;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Get Operation.
+ */
+public class PrimitivePrivateFieldsStorIOSQLiteGetResolver extends DefaultGetResolver<PrimitivePrivateFields> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public PrimitivePrivateFields mapFromCursor(@NonNull Cursor cursor) {
+        PrimitivePrivateFields object = new PrimitivePrivateFields();
+
+        object.setField1(cursor.getInt(cursor.getColumnIndex("field1")) == 1);
+        object.setField2(cursor.getShort(cursor.getColumnIndex("field2")));
+        object.setField3(cursor.getInt(cursor.getColumnIndex("field3")));
+        object.setField4(cursor.getLong(cursor.getColumnIndex("field4")));
+        object.setField5(cursor.getFloat(cursor.getColumnIndex("field5")));
+        object.setField6(cursor.getDouble(cursor.getColumnIndex("field6")));
+        object.setField7(cursor.getString(cursor.getColumnIndex("field7")));
+        object.setField8(cursor.getBlob(cursor.getColumnIndex("field8")));
+
+        return object;
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsStorIOSQLitePutResolver.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/PrimitivePrivateFieldsStorIOSQLitePutResolver.java
@@ -1,0 +1,56 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+import android.content.ContentValues;
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio.sqlite.operations.put.DefaultPutResolver;
+import com.pushtorefresh.storio.sqlite.queries.InsertQuery;
+import com.pushtorefresh.storio.sqlite.queries.UpdateQuery;
+import java.lang.Override;
+
+/**
+ * Generated resolver for Put Operation.
+ */
+public class PrimitivePrivateFieldsStorIOSQLitePutResolver extends DefaultPutResolver<PrimitivePrivateFields> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public InsertQuery mapToInsertQuery(@NonNull PrimitivePrivateFields object) {
+        return InsertQuery.builder()
+                .table("table")
+                .build();}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public UpdateQuery mapToUpdateQuery(@NonNull PrimitivePrivateFields object) {
+        return UpdateQuery.builder()
+                .table("table")
+                .where("field4 = ?")
+                .whereArgs(object.getField4())
+                .build();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public ContentValues mapToContentValues(@NonNull PrimitivePrivateFields object) {
+        ContentValues contentValues = new ContentValues(8);
+
+        contentValues.put("field1", object.isField1());
+        contentValues.put("field2", object.getField2());
+        contentValues.put("field3", object.getField3());
+        contentValues.put("field4", object.getField4());
+        contentValues.put("field5", object.getField5());
+        contentValues.put("field6", object.getField6());
+        contentValues.put("field7", object.getField7());
+        contentValues.put("field8", object.getField8());
+
+        return contentValues;
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/PrivateFieldWithCorrespondingAccessors.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/PrivateFieldWithCorrespondingAccessors.java
@@ -1,0 +1,16 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+@StorIOSQLiteType(table = "table")
+public class PrivateFieldWithCorrespondingAccessors {
+
+    @StorIOSQLiteColumn(name = "id", key = true)
+    private long id;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/PrivateFieldWithIsCornerCase.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/PrivateFieldWithIsCornerCase.java
@@ -1,0 +1,27 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+@StorIOSQLiteType(table = "table")
+public class PrivateFieldWithIsCornerCase {
+
+    @StorIOSQLiteColumn(name = "id", key = true)
+    private long id;
+
+    @StorIOSQLiteColumn(name = "is_flag")
+    private boolean isFlag;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public boolean isFlag() {
+        return isFlag;
+    }
+
+    public void setFlag(boolean flag) {
+        isFlag = flag;
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/PrivateFieldWithIsGetter.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/PrivateFieldWithIsGetter.java
@@ -1,0 +1,27 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+@StorIOSQLiteType(table = "table")
+public class PrivateFieldWithIsGetter {
+
+    @StorIOSQLiteColumn(name = "id", key = true)
+    private long id;
+
+    @StorIOSQLiteColumn(name = "flag")
+    private boolean flag;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public boolean isFlag() {
+        return flag;
+    }
+
+    public void setFlag(boolean flag) {
+        this.flag = flag;
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/PrivateFieldWithNameStartingWithIs.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/PrivateFieldWithNameStartingWithIs.java
@@ -1,0 +1,27 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+@StorIOSQLiteType(table = "table")
+public class PrivateFieldWithNameStartingWithIs {
+
+    @StorIOSQLiteColumn(name = "id", key = true)
+    private long id;
+
+    @StorIOSQLiteColumn(name = "is_flag")
+    private boolean isFlag;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public boolean isFlag() {
+        return isFlag;
+    }
+
+    public void setFlag(boolean flag) {
+        isFlag = flag;
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/PrivateFieldWithoutAccessors.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/PrivateFieldWithoutAccessors.java
@@ -1,0 +1,8 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+@StorIOSQLiteType(table = "table")
+public class PrivateFieldWithoutAccessors {
+
+    @StorIOSQLiteColumn(name = "id", key = true)
+    private long id;
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/PrivateFieldWithoutGetter.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/PrivateFieldWithoutGetter.java
@@ -1,8 +1,12 @@
 package com.pushtorefresh.storio.sqlite.annotations;
 
 @StorIOSQLiteType(table = "table")
-public class PrivateField {
+public class PrivateFieldWithoutGetter {
 
     @StorIOSQLiteColumn(name = "id", key = true)
     private long id;
+
+    public void setId(long id) {
+        this.id = id;
+    }
 }

--- a/storio-sqlite-annotations-processor-test/src/test/resources/PrivateFieldWithoutSetter.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/PrivateFieldWithoutSetter.java
@@ -1,0 +1,12 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+@StorIOSQLiteType(table = "table")
+public class PrivateFieldWithoutSetter {
+
+    @StorIOSQLiteColumn(name = "id", key = true)
+    private long id;
+
+    public long getId() {
+        return id;
+    }
+}

--- a/storio-sqlite-annotations-processor-test/src/test/resources/PrivateMethod.java
+++ b/storio-sqlite-annotations-processor-test/src/test/resources/PrivateMethod.java
@@ -1,0 +1,10 @@
+package com.pushtorefresh.storio.sqlite.annotations;
+
+@StorIOSQLiteType(table = "table")
+public class PrivateMethod {
+
+    @StorIOSQLiteColumn(name = "id", key = true)
+    private long id() {
+        return 0;
+    }
+}

--- a/storio-sqlite-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/sqlite/annotations/processor/StorIOSQLiteProcessor.kt
+++ b/storio-sqlite-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/sqlite/annotations/processor/StorIOSQLiteProcessor.kt
@@ -17,6 +17,7 @@ import com.pushtorefresh.storio.sqlite.annotations.processor.introspection.StorI
 import com.pushtorefresh.storio.sqlite.annotations.processor.introspection.StorIOSQLiteTypeMeta
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.element.*
+import javax.lang.model.element.Modifier.*
 import javax.lang.model.util.Elements
 import javax.tools.Diagnostic.Kind.WARNING
 
@@ -57,7 +58,7 @@ open class StorIOSQLiteProcessor : StorIOAnnotationsProcessor<StorIOSQLiteTypeMe
         val simpleName = classElement.simpleName.toString()
         val packageName = elementUtils.getPackageOf(classElement).qualifiedName.toString()
 
-        return StorIOSQLiteTypeMeta(simpleName, packageName, storIOSQLiteType, Modifier.ABSTRACT in classElement.modifiers)
+        return StorIOSQLiteTypeMeta(simpleName, packageName, storIOSQLiteType, ABSTRACT in classElement.modifiers)
     }
 
     /**
@@ -131,6 +132,13 @@ open class StorIOSQLiteProcessor : StorIOAnnotationsProcessor<StorIOSQLiteTypeMe
 
         if (column.name.isEmpty()) {
             throw ProcessingException(annotatedField, "Column name is empty: ${annotatedField.simpleName}")
+        }
+
+        if (PRIVATE in annotatedField.modifiers) {
+            // can't be null since we validated it before
+            val (getter, setter) = accessorsMap[annotatedField.simpleName.toString()]!!
+
+            return StorIOSQLiteColumnMeta(annotatedField.enclosingElement, annotatedField, annotatedField.simpleName.toString(), javaType, column, getter, setter)
         }
 
         return StorIOSQLiteColumnMeta(annotatedField.enclosingElement, annotatedField, annotatedField.simpleName.toString(), javaType, column)

--- a/storio-sqlite-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/sqlite/annotations/processor/StorIOSQLiteProcessor.kt
+++ b/storio-sqlite-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/sqlite/annotations/processor/StorIOSQLiteProcessor.kt
@@ -16,8 +16,12 @@ import com.pushtorefresh.storio.sqlite.annotations.processor.introspection.StorI
 import com.pushtorefresh.storio.sqlite.annotations.processor.introspection.StorIOSQLiteCreatorMeta
 import com.pushtorefresh.storio.sqlite.annotations.processor.introspection.StorIOSQLiteTypeMeta
 import javax.annotation.processing.RoundEnvironment
-import javax.lang.model.element.*
-import javax.lang.model.element.Modifier.*
+import javax.lang.model.element.Element
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.Modifier.ABSTRACT
+import javax.lang.model.element.Modifier.PRIVATE
+import javax.lang.model.element.TypeElement
 import javax.lang.model.util.Elements
 import javax.tools.Diagnostic.Kind.WARNING
 

--- a/storio-sqlite-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/sqlite/annotations/processor/generate/GetResolverGenerator.kt
+++ b/storio-sqlite-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/sqlite/annotations/processor/generate/GetResolverGenerator.kt
@@ -58,7 +58,11 @@ object GetResolverGenerator : Generator<StorIOSQLiteTypeMeta> {
             // otherwise -> if primitive and value from cursor null -> fail early
             if (isBoxed) builder.beginControlFlow("if (!cursor.isNull(\$L))", columnIndex)
 
-            builder.addStatement("object.\$L = cursor.\$L", columnMeta.elementName, getFromCursor)
+            if (columnMeta.needAccessors) {
+                builder.addStatement("object.\$L(cursor.\$L)", columnMeta.setter, getFromCursor)
+            } else {
+                builder.addStatement("object.\$L = cursor.\$L", columnMeta.elementName, getFromCursor)
+            }
 
             if (isBoxed) builder.endControlFlow()
         }
@@ -99,8 +103,7 @@ object GetResolverGenerator : Generator<StorIOSQLiteTypeMeta> {
                 builder.addStatement("\$L = cursor.\$L", columnMeta.realElementName, getFromCursor)
                 builder.endControlFlow()
             } else {
-                builder.addStatement("\$T \$L = cursor.\$L", name, columnMeta.realElementName,
-                        getFromCursor)
+                builder.addStatement("\$T \$L = cursor.\$L", name, columnMeta.realElementName, getFromCursor)
             }
 
             if (!first) paramsBuilder.append(", ")

--- a/storio-sqlite-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/sqlite/annotations/processor/generate/PutResolverGenerator.kt
+++ b/storio-sqlite-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/sqlite/annotations/processor/generate/PutResolverGenerator.kt
@@ -87,9 +87,9 @@ $INDENT.build();
         typeMeta.columns.values.forEach { columnMeta ->
             val ignoreNull = columnMeta.storIOColumn.ignoreNull
             if (ignoreNull) {
-                builder.beginControlFlow("if (object.\$L != null)", "${columnMeta.elementName}${if (columnMeta.isMethod) "()" else ""}")
+                builder.beginControlFlow("if (object.\$L != null)", columnMeta.contextAwareName)
             }
-            builder.addStatement("contentValues.put(\$S, object.\$L)", columnMeta.storIOColumn.name, "${columnMeta.elementName}${if (columnMeta.isMethod) "()" else ""}")
+            builder.addStatement("contentValues.put(\$S, object.\$L)", columnMeta.storIOColumn.name, columnMeta.contextAwareName)
             if (ignoreNull) builder.endControlFlow()
         }
 

--- a/storio-sqlite-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/sqlite/annotations/processor/generate/PutResolverGenerator.kt
+++ b/storio-sqlite-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/sqlite/annotations/processor/generate/PutResolverGenerator.kt
@@ -60,11 +60,11 @@ object PutResolverGenerator : Generator<StorIOSQLiteTypeMeta> {
                         .addAnnotation(ANDROID_NON_NULL_ANNOTATION_CLASS_NAME)
                         .build())
                 .addCode("""return UpdateQuery.builder()
-$INDENT.table(${"$"}S)
-$INDENT.where(${"$"}S)
-$INDENT.whereArgs(${"$"}L)
-$INDENT.build();
-""",
+                            $INDENT.table(${"$"}S)
+                            $INDENT.where(${"$"}S)
+                            $INDENT.whereArgs(${"$"}L)
+                            $INDENT.build();
+                         """.trimIndent(),
                         typeMeta.storIOType.table,
                         where[QueryGenerator.WHERE_CLAUSE],
                         where[QueryGenerator.WHERE_ARGS])

--- a/storio-sqlite-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/sqlite/annotations/processor/generate/QueryGenerator.kt
+++ b/storio-sqlite-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/sqlite/annotations/processor/generate/QueryGenerator.kt
@@ -23,7 +23,7 @@ object QueryGenerator {
                     whereArgs
                             .append(varName)
                             .append(".")
-                            .append(columnMeta.elementName)
+                            .append(columnMeta.contextAwareName)
                 } else {
                     whereClause
                             .append(" AND ")
@@ -34,11 +34,8 @@ object QueryGenerator {
                             .append(", ")
                             .append(varName)
                             .append(".")
-                            .append(columnMeta.elementName)
+                            .append(columnMeta.contextAwareName)
                 }
-
-                if (columnMeta.isMethod) whereArgs.append("()")
-
                 i++
             }
         }

--- a/storio-sqlite-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/sqlite/annotations/processor/introspection/StorIOSQLiteColumnMeta.kt
+++ b/storio-sqlite-annotations-processor/src/main/kotlin/com/pushtorefresh/storio/sqlite/annotations/processor/introspection/StorIOSQLiteColumnMeta.kt
@@ -10,10 +10,14 @@ class StorIOSQLiteColumnMeta(
         element: Element,
         fieldName: String,
         javaType: JavaType,
-        storIOColumn: StorIOSQLiteColumn)
+        storIOColumn: StorIOSQLiteColumn,
+        getter: String? = null,
+        setter: String? = null)
     : StorIOColumnMeta<StorIOSQLiteColumn>(
         enclosingElement,
         element,
         fieldName,
         javaType,
-        storIOColumn)
+        storIOColumn,
+        getter,
+        setter)


### PR DESCRIPTION
With this PR it is possible to annotate Kotlin properties directly utilising getters and setter instead of direct access to fields.
Also, it resolves https://github.com/pushtorefresh/storio/issues/735 since there is no need anymore to map fields to constructor parameters.