### PR TITLE
Add Gradle plugin for automatic Sonatype releases.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ buildscript {
         // Kotlin
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
+        // Automatic releases to Sonatype.
+        classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.8.0'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -149,3 +152,8 @@ subprojects {
     }
 }
 
+apply plugin: 'io.codearte.nexus-staging'
+
+nexusStaging {
+    packageGroup = 'com.pushtorefresh'
+}


### PR DESCRIPTION
This is the first step in Sonatype release automation #766.

Release can be done on machine with credentials for it by running `./gradlew clean uploadArchives --info closeAndReleaseRepository`.

Next step would be adding encrypted credentials to Travis and setting up builds scripts so that pushing git tag would trigger the release.

v1.13.0 was released using this plugin.
