### PR TITLE
Automate release process.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,6 @@ def getRuntimeJar() {
 project.ext.preDexLibs = !project.hasProperty('disablePreDex')
 
 subprojects {
-
     project.plugins.whenPluginAdded { plugin ->
         if ('com.android.build.gradle.AppPlugin'.equals(plugin.class.name)
                 || 'com.android.build.gradle.LibraryPlugin'.equals(plugin.class.name)) {
@@ -148,8 +147,70 @@ subprojects {
     }
 }
 
+def gitTag() {
+    def tag = 'git tag --list --points-at HEAD'.execute((List) null, rootProject.projectDir).text.trim()
+
+    if (tag.split(System.lineSeparator()).length > 1) {
+        throw new IllegalStateException("gitTag is accessed but commit has multiple tags: $tag")
+    }
+
+    return tag
+}
+
+def projectVersion() {
+    def tag = gitTag()
+
+    if (tag.startsWith('v')) {
+        return tag.substring(1)
+    } else if (tag.isEmpty()) {
+        return 'development'
+    }
+
+    return tag
+}
+
+def validateTagAndVersion() {
+    if (gitTag().isEmpty()) {
+        throw new IllegalStateException('Publishing is not allowed because current commit has no tag')
+    }
+
+    if (projectVersion().isEmpty()) {
+        throw new IllegalStateException('Publishing is not allowed because current projectVersion is empty')
+    }
+}
+
+allprojects {
+    ext.'signing.password' = System.getenv('GPG_PASSPHRASE')
+}
+
+ext.VERSION_NAME = projectVersion()
+
+def isReleaseBuild() {
+    return !projectVersion().equals('development')
+}
+
+def getReleaseRepositoryUrl() {
+    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
+            : 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+}
+
+def getSnapshotRepositoryUrl() {
+    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
+            : 'https://oss.sonatype.org/content/repositories/snapshots/'
+}
+
+def getRepositoryUsername() {
+    return System.getenv('SONATYPE_USERNAME')
+}
+
+def getRepositoryPassword() {
+    return System.getenv('SONATYPE_PASSWORD')
+}
+
 apply plugin: 'io.codearte.nexus-staging'
 
 nexusStaging {
     packageGroup = 'com.pushtorefresh'
+    username = getRepositoryUsername()
+    password = getRepositoryPassword()
 }

--- a/ci.sh
+++ b/ci.sh
@@ -2,6 +2,28 @@
 set -e
 
 # Please run it from root project directory
+
 # For some reason test for annotation processor are failing on a regular CI setup.
 # So we had to exclude test task for it from the main build process and execute it as a separate command.
-./gradlew clean build checkstyle -PdisablePreDex -x :storio-sqlite-annotations-processor-test:test -x :storio-content-resolver-annotations-processor-test:test && ./gradlew :storio-sqlite-annotations-processor-test:testDebugUnitTest && ./gradlew :storio-content-resolver-annotations-processor-test:testDebugUnitTest
+./gradlew clean build checkstyle -PdisablePreDex -x :storio-sqlite-annotations-processor-test:test -x :storio-content-resolver-annotations-processor-test:test
+./gradlew :storio-sqlite-annotations-processor-test:testDebugUnitTest
+./gradlew :storio-content-resolver-annotations-processor-test:testDebugUnitTest
+
+if git describe --exact-match --tags $(git log -n1 --pretty='%h') ; then
+    echo "Git tag detected, launching release process..."
+
+    if [ -z "$GPG_SECRET_KEYS" ]; then
+        echo "Put base64 encoded gpg secret key for signing into GPG_SECRET_KEYS env variable."
+        exit 1
+    fi
+
+    if [ -z "$GPG_OWNERTRUST" ]; then
+        echo "Put base64 encoded gpg ownertrust for signing into GPG_OWNERTRUST env variable."
+        exit 1
+    fi
+
+    echo $GPG_SECRET_KEYS | base64 --decode | gpg --import;
+    echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust;
+
+    ./gradlew uploadArchives closeAndReleaseRepository --info
+fi

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 VERSION_CODE=29
-VERSION_NAME=1.13.0
 GROUP=com.pushtorefresh.storio
 
 POM_DESCRIPTION=Modern API for SQLiteDatabase and ContentResolver

--- a/gradle/publish-android-lib.gradle
+++ b/gradle/publish-android-lib.gradle
@@ -32,28 +32,6 @@ android.libraryVariants.all { variant ->
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-def isReleaseBuild() {
-    return VERSION_NAME.contains('SNAPSHOT') == false
-}
-
-def getReleaseRepositoryUrl() {
-    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-            : 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-}
-
-def getSnapshotRepositoryUrl() {
-    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-            : 'https://oss.sonatype.org/content/repositories/snapshots/'
-}
-
-def getRepositoryUsername() {
-    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ''
-}
-
-def getRepositoryPassword() {
-    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ''
-}
-
 afterEvaluate { project ->
     uploadArchives {
         repositories {
@@ -142,4 +120,12 @@ afterEvaluate { project ->
         archives androidSourcesJar
         archives androidJavadocsJar
     }
+
+    task validatePublishing {
+        doLast {
+            validateTagAndVersion()
+        }
+    }
+
+    uploadArchives.dependsOn validatePublishing
 }

--- a/gradle/publish-java-lib.gradle
+++ b/gradle/publish-java-lib.gradle
@@ -17,28 +17,6 @@
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-def isReleaseBuild() {
-    return VERSION_NAME.contains('SNAPSHOT') == false
-}
-
-def getReleaseRepositoryUrl() {
-    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-            : 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-}
-
-def getSnapshotRepositoryUrl() {
-    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-            : 'https://oss.sonatype.org/content/repositories/snapshots/'
-}
-
-def getRepositoryUsername() {
-    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ''
-}
-
-def getRepositoryPassword() {
-    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ''
-}
-
 afterEvaluate { project ->
     uploadArchives {
         repositories {
@@ -114,4 +92,12 @@ afterEvaluate { project ->
         archives sourcesJar
         archives javadocJar
     }
+
+    task validatePublishing {
+        doLast {
+            validateTagAndVersion()
+        }
+    }
+
+    uploadArchives.dependsOn validatePublishing
 }


### PR DESCRIPTION
Alright, I think I've finally managed to automate release process for StorIO, it was hard and I'm not sure if it'll work right away, but it should.

I combined multiple solutions and existing plugins I've used before, we now should be able to publish release to maven central by simply pushing a tag. You can do it right on GitHub releases page. 

Very similar set of scripts works for [gojuno/composer](https://github.com/gojuno/composer), [gojuno/swarmer](https://github.com/gojuno/swarmer), [gojuno/koptional](https://github.com/gojuno/koptional) and so on. 

However in StorIO we use Sonatype's Maven Central instead of Bintray's Jcenter which in certain ways complicate things but in others makes it easier.

Travis CI now securely (relatively) stores credentials to sign and push release to Maven Central, that should increase our bus factor from 1 (me) to 3 (@nikitin-da, @geralt-encore and me).