### PR TITLE
Fix Travis log overflow, update Android SDK tools 25.2.3 → 3859397.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ before_install:
   - export ANDROID_HOME="$HOME"/android-sdk
   - mkdir -p "$ANDROID_HOME"
   - export ANDROID_SDK_FILE_NAME=sdk-tools-darwin-3859397.zip
-  - curl --fail https://dl.google.com/android/repository/$ANDROID_SDK_FILE_NAME --progress-bar --location --output $ANDROID_SDK_FILE_NAME
+  - curl --fail https://dl.google.com/android/repository/$ANDROID_SDK_FILE_NAME --silent --location --output $ANDROID_SDK_FILE_NAME
   - unzip -qq $ANDROID_SDK_FILE_NAME -d "$ANDROID_HOME"
   - rm $ANDROID_SDK_FILE_NAME
-  - export ANDROID_SDK_INSTALL_COMPONENT="echo \"y\" | \"$ANDROID_HOME\"/tools/bin/sdkmanager"
+  - export ANDROID_SDK_INSTALL_COMPONENT="echo \"y\" | \"$ANDROID_HOME\"/tools/bin/sdkmanager > /dev/null"
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"tools"'
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"platform-tools"'
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"build-tools;25.0.2"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ before_install:
   - pip install --user codecov
   - export ANDROID_HOME="$HOME"/android-sdk
   - mkdir -p "$ANDROID_HOME"
-  - export ANDROID_SDK_FILE_NAME=tools_r25.2.3-linux.zip
-  - curl https://dl.google.com/android/repository/$ANDROID_SDK_FILE_NAME --progress-bar --location --output $ANDROID_SDK_FILE_NAME
+  - export ANDROID_SDK_FILE_NAME=sdk-tools-darwin-3859397.zip
+  - curl --fail https://dl.google.com/android/repository/$ANDROID_SDK_FILE_NAME --progress-bar --location --output $ANDROID_SDK_FILE_NAME
   - unzip -qq $ANDROID_SDK_FILE_NAME -d "$ANDROID_HOME"
   - rm $ANDROID_SDK_FILE_NAME
-  - export ANDROID_SDK_INSTALL_COMPONENT="echo \"y\" | \"$ANDROID_HOME\"/tools/bin/sdkmanager --verbose"
+  - export ANDROID_SDK_INSTALL_COMPONENT="echo \"y\" | \"$ANDROID_HOME\"/tools/bin/sdkmanager"
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"tools"'
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"platform-tools"'
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"build-tools;25.0.2"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - mkdir -p "$ANDROID_HOME"
   - export ANDROID_SDK_FILE_NAME=tools_r25.2.3-linux.zip
   - curl https://dl.google.com/android/repository/$ANDROID_SDK_FILE_NAME --progress-bar --location --output $ANDROID_SDK_FILE_NAME
-  - unzip $ANDROID_SDK_FILE_NAME -d "$ANDROID_HOME"
+  - unzip -qq $ANDROID_SDK_FILE_NAME -d "$ANDROID_HOME"
   - rm $ANDROID_SDK_FILE_NAME
   - export ANDROID_SDK_INSTALL_COMPONENT="echo \"y\" | \"$ANDROID_HOME\"/tools/bin/sdkmanager --verbose"
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"tools"'


### PR DESCRIPTION
Should reduce amount of logs, sometimes Travis shuts down the build when we overflow 4mbs of logs:

![capture](https://user-images.githubusercontent.com/967132/31277861-c5e8ec24-aa57-11e7-9bcc-59afd3183992.PNG)
