### PR TITLE
Fix incorrect test parallelWritesWithoutTransaction.

### DIFF
--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/integration/BaseTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/integration/BaseTest.java
@@ -14,6 +14,8 @@ import com.pushtorefresh.storio2.sqlite.operations.put.PutResult;
 import com.pushtorefresh.storio2.sqlite.operations.put.PutResults;
 
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
@@ -29,6 +31,9 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21)
 public abstract class BaseTest {
+
+    @Rule
+    public Timeout timeout = Timeout.seconds(30);
 
     @NonNull
     protected StorIOSQLite storIOSQLite;

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/integration/NotifyAboutChangesTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/integration/NotifyAboutChangesTest.java
@@ -6,7 +6,10 @@ import android.os.SystemClock;
 import com.pushtorefresh.storio2.sqlite.BuildConfig;
 import com.pushtorefresh.storio2.sqlite.Changes;
 import com.pushtorefresh.storio2.sqlite.StorIOSQLite;
+import com.pushtorefresh.storio2.test.Repeat;
+import com.pushtorefresh.storio2.test.RepeatRule;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -27,6 +30,9 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21)
 public class NotifyAboutChangesTest extends BaseTest {
+
+    @Rule
+    public RepeatRule repeat = new RepeatRule();
 
     @Test
     public void notifyAboutChange() {
@@ -197,11 +203,12 @@ public class NotifyAboutChangesTest extends BaseTest {
     }
 
     @Test
+    @Repeat(times = 20)
     public void shouldReceiveOneNotificationWithAllAffectedTablesInTransactionWithMultipleThreads() throws InterruptedException {
         final String table1 = "test_table1";
         final String table2 = "test_table2";
 
-        final int numberOfThreads = 100;
+        final int numberOfThreads = 50;
 
         final TestSubscriber<Changes> testSubscriber = new TestSubscriber<Changes>();
 
@@ -239,7 +246,7 @@ public class NotifyAboutChangesTest extends BaseTest {
         // Steady!
         startAllThreadsLock.countDown(); // Go!
 
-        assertThat(allThreadsFinishedLock.await(20, SECONDS)).isTrue();
+        assertThat(allThreadsFinishedLock.await(25, SECONDS)).isTrue();
 
         // While we in transaction, no changes should be sent.
         assertThat(testSubscriber.getOnNextEvents()).hasSize(0);
@@ -247,6 +254,7 @@ public class NotifyAboutChangesTest extends BaseTest {
         lowLevel.endTransaction();
 
         testSubscriber.assertNoErrors();
+
         List<Changes> actualChanges = testSubscriber.getOnNextEvents();
         assertThat(actualChanges).hasSize(1);
         assertThat(actualChanges.get(0).affectedTables()).containsOnly("test_table1", "test_table2");

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/integration/NotifyAboutChangesTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/integration/NotifyAboutChangesTest.java
@@ -6,6 +6,7 @@ import android.os.SystemClock;
 import com.pushtorefresh.storio2.sqlite.BuildConfig;
 import com.pushtorefresh.storio2.sqlite.Changes;
 import com.pushtorefresh.storio2.sqlite.StorIOSQLite;
+import com.pushtorefresh.storio2.test.ConcurrencyTesting;
 import com.pushtorefresh.storio2.test.Repeat;
 import com.pushtorefresh.storio2.test.RepeatRule;
 
@@ -208,7 +209,7 @@ public class NotifyAboutChangesTest extends BaseTest {
         final String table1 = "test_table1";
         final String table2 = "test_table2";
 
-        final int numberOfThreads = 50;
+        final int numberOfThreads = ConcurrencyTesting.optimalTestThreadsCount();
 
         final TestSubscriber<Changes> testSubscriber = new TestSubscriber<Changes>();
 

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/integration/RxQueryTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/integration/RxQueryTest.java
@@ -6,6 +6,7 @@ import com.pushtorefresh.storio2.sqlite.BuildConfig;
 import com.pushtorefresh.storio2.sqlite.Changes;
 import com.pushtorefresh.storio2.sqlite.queries.Query;
 import com.pushtorefresh.storio2.test.AbstractEmissionChecker;
+import com.pushtorefresh.storio2.test.ConcurrencyTesting;
 import com.pushtorefresh.storio2.test.Repeat;
 import com.pushtorefresh.storio2.test.RepeatRule;
 
@@ -159,7 +160,7 @@ public class RxQueryTest extends BaseTest {
     @Test
     @Repeat(times = 20)
     public void parallelPutWithoutGlobalTransaction() {
-        final int numberOfParallelPuts = 50;
+        final int numberOfParallelPuts = ConcurrencyTesting.optimalTestThreadsCount();
 
         TestSubscriber<Changes> testSubscriber = new TestSubscriber<Changes>();
 

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/integration/RxQueryTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/integration/RxQueryTest.java
@@ -159,42 +159,45 @@ public class RxQueryTest extends BaseTest {
 
     @Test
     @Repeat(times = 20)
-    public void parallelPutWithoutGlobalTransaction() {
-        final int numberOfParallelPuts = ConcurrencyTesting.optimalTestThreadsCount();
+    public void concurrentPutWithoutGlobalTransaction() throws InterruptedException {
+        final int numberOfConcurrentPuts = ConcurrencyTesting.optimalTestThreadsCount();
 
         TestSubscriber<Changes> testSubscriber = new TestSubscriber<Changes>();
 
         storIOSQLite
                 .observeChangesInTable(TweetTableMeta.TABLE)
-                .take(numberOfParallelPuts)
                 .subscribe(testSubscriber);
 
-        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        final CountDownLatch concurrentPutLatch = new CountDownLatch(1);
+        final CountDownLatch allPutsDoneLatch = new CountDownLatch(numberOfConcurrentPuts);
 
-        for (int i = 0; i < numberOfParallelPuts; i++) {
-            final int copyOfCurrentI = i;
+        for (int i = 0; i < numberOfConcurrentPuts; i++) {
+            final int iCopy = i;
+
             new Thread(new Runnable() {
                 @Override
                 public void run() {
                     try {
-                        countDownLatch.await();
+                        concurrentPutLatch.await();
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);
                     }
 
                     storIOSQLite
                             .put()
-                            .object(Tweet.newInstance(null, 1L, "Some text: " + copyOfCurrentI))
+                            .object(Tweet.newInstance(null, 1L, "Some text: " + iCopy))
                             .prepare()
                             .executeAsBlocking();
+
+                    allPutsDoneLatch.countDown();
                 }
             }).start();
         }
 
-        // Release the KRAKEN!
-        countDownLatch.countDown();
+        // Start concurrent Put operations.
+        concurrentPutLatch.countDown();
 
-        testSubscriber.awaitTerminalEvent();
+        assertThat(allPutsDoneLatch.await(25, SECONDS)).isTrue();
         testSubscriber.assertNoErrors();
 
         // Put operation creates short-term transaction which might result in merge of some notifications.
@@ -203,7 +206,7 @@ public class RxQueryTest extends BaseTest {
         // - all notifications merged → isEqualTo(1)
         // Obviously truth is somewhere between those (depends on CPU of machine that runs test).
         assertThat(testSubscriber.getOnNextEvents().size())
-                .isLessThanOrEqualTo(numberOfParallelPuts)
+                .isLessThanOrEqualTo(numberOfConcurrentPuts)
                 .isGreaterThanOrEqualTo(1);
     }
 

--- a/storio-test-common/build.gradle
+++ b/storio-test-common/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     provided libraries.supportAnnotations
     provided libraries.rxJava
 
+    compile libraries.junit
     compile libraries.mockitoCore
 
     testCompile libraries.junit

--- a/storio-test-common/src/main/java/com/pushtorefresh/storio2/test/ConcurrencyTesting.java
+++ b/storio-test-common/src/main/java/com/pushtorefresh/storio2/test/ConcurrencyTesting.java
@@ -7,6 +7,6 @@ public class ConcurrencyTesting {
     }
 
     public static int optimalTestThreadsCount() {
-        return Runtime.getRuntime().availableProcessors() * 2;
+        return Math.max(Runtime.getRuntime().availableProcessors() * 2, 4);
     }
 }

--- a/storio-test-common/src/main/java/com/pushtorefresh/storio2/test/ConcurrencyTesting.java
+++ b/storio-test-common/src/main/java/com/pushtorefresh/storio2/test/ConcurrencyTesting.java
@@ -3,7 +3,7 @@ package com.pushtorefresh.storio2.test;
 public class ConcurrencyTesting {
 
     private ConcurrencyTesting() {
-        throw new IllegalStateException("No instances!");
+        throw new IllegalStateException("No instances please.");
     }
 
     public static int optimalTestThreadsCount() {

--- a/storio-test-common/src/main/java/com/pushtorefresh/storio2/test/ConcurrencyTesting.java
+++ b/storio-test-common/src/main/java/com/pushtorefresh/storio2/test/ConcurrencyTesting.java
@@ -1,0 +1,12 @@
+package com.pushtorefresh.storio2.test;
+
+public class ConcurrencyTesting {
+
+    private ConcurrencyTesting() {
+        throw new IllegalStateException("No instances!");
+    }
+
+    public static int optimalTestThreadsCount() {
+        return Runtime.getRuntime().availableProcessors() * 2;
+    }
+}

--- a/storio-test-common/src/main/java/com/pushtorefresh/storio2/test/Repeat.java
+++ b/storio-test-common/src/main/java/com/pushtorefresh/storio2/test/Repeat.java
@@ -1,0 +1,13 @@
+package com.pushtorefresh.storio2.test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface Repeat {
+    int times();
+}

--- a/storio-test-common/src/main/java/com/pushtorefresh/storio2/test/RepeatRule.java
+++ b/storio-test-common/src/main/java/com/pushtorefresh/storio2/test/RepeatRule.java
@@ -1,0 +1,36 @@
+package com.pushtorefresh.storio2.test;
+
+import android.support.annotation.NonNull;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class RepeatRule implements TestRule {
+
+    @Override
+    @NonNull
+    public Statement apply(@NonNull final Statement test, @NonNull final Description description) {
+        final Repeat repeat = description.getAnnotation(Repeat.class);
+
+        if (repeat != null) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    final int times = repeat.times();
+
+                    if (times < 1) {
+                        throw new IllegalArgumentException("Repeat times should be >= 1, times = " + times);
+                    }
+
+                    for (int i = 0; i < times; i++) {
+                        System.out.println(description.getMethodName() + " iteration " + (i + 1));
+                        test.evaluate();
+                    }
+                }
+            };
+        } else {
+            return test;
+        }
+    }
+}

--- a/storio-test-common/src/test/java/com/pushtorefresh/storio2/test/ConcurrencyTestingTest.java
+++ b/storio-test-common/src/test/java/com/pushtorefresh/storio2/test/ConcurrencyTestingTest.java
@@ -1,0 +1,24 @@
+package com.pushtorefresh.storio2.test;
+
+import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class ConcurrencyTestingTest {
+
+    @Test
+    public void optimalTestThreadsCountIsAtLeast4() {
+        assertThat(ConcurrencyTesting.optimalTestThreadsCount()).isGreaterThanOrEqualTo(4);
+    }
+
+    @Test
+    public void constructorMustBePrivateAndThrowException() {
+        PrivateConstructorChecker
+                .forClass(ConcurrencyTesting.class)
+                .expectedTypeOfException(IllegalStateException.class)
+                .expectedExceptionMessage("No instances please.")
+                .check();
+    }
+}

--- a/storio-test-common/src/test/java/com/pushtorefresh/storio2/test/RepeatRuleTest.java
+++ b/storio-test-common/src/test/java/com/pushtorefresh/storio2/test/RepeatRuleTest.java
@@ -1,0 +1,71 @@
+package com.pushtorefresh.storio2.test;
+
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RepeatRuleTest {
+
+    private Statement test = mock(Statement.class);
+    private Description description = mock(Description.class);
+    private Repeat repeat = mock(Repeat.class);
+
+    @Test
+    public void repeats10Times() throws Throwable {
+        when(description.getAnnotation(Repeat.class)).thenReturn(repeat);
+        when(repeat.times()).thenReturn(10);
+
+        new RepeatRule().apply(test, description).evaluate();
+
+        verify(test, times(10)).evaluate();
+    }
+
+    @Test
+    public void noAnnotation() throws Throwable {
+        when(description.getAnnotation(Repeat.class)).thenReturn(null);
+
+        new RepeatRule().apply(test, description).evaluate();
+
+        verify(test).evaluate();
+    }
+
+    @Test
+    public void lessThan1Time() throws Throwable {
+        when(description.getAnnotation(Repeat.class)).thenReturn(repeat);
+        when(repeat.times()).thenReturn(0);
+
+        try {
+            new RepeatRule().apply(test, description).evaluate();
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessage("Repeat times should be >= 1, times = 0");
+        }
+    }
+
+    @Test
+    public void lazyWithoutAnnotation() throws Throwable {
+        when(description.getAnnotation(Repeat.class)).thenReturn(null);
+
+        new RepeatRule().apply(test, description);
+
+        verify(test, never()).evaluate();
+    }
+
+    @Test
+    public void lazyWithAnnotation() throws Throwable {
+        when(description.getAnnotation(Repeat.class)).thenReturn(repeat);
+        when(repeat.times()).thenReturn(10);
+
+        new RepeatRule().apply(test, description);
+
+        verify(test, never()).evaluate();
+    }
+}


### PR DESCRIPTION
Fixes #826.

TL;TR: test was incorrect, because default PutResolver uses short-term transaction thus StorIO has all rights to merge notifications, so sometimes we've seen flakiness due to notifications merge.

CI was freezing because we were awaiting for wrong amount of notifications without timeout, this PR adds timeout to all tests and `RepeatRule` to make sure our concurrent tests are good.

Thanks a lot @nikitin-da for his work in #827, those logs really helped to figure out what was wrong!