### PR TITLE
Add automatic deploy hooks to Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,17 @@ before_install:
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"extras;google;m2repository"'
 
 script:
-  - sh ci.sh
+  - ci.sh
   
 after_success:
   - codecov
+
+deploy:
+  skip_cleanup: true
+  - provider: script
+    script: ci.sh publish=true
+    on:
+      tags: true
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,14 @@ before_install:
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"extras;google;m2repository"'
 
 script:
-  - ci.sh
+  - ./ci.sh
   
 after_success:
   - codecov
 
 deploy:
   - provider: script
-    script: ci.sh publish=true
+    script: ./ci.sh publish=true
     skip_cleanup: true
     on:
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ after_success:
   - codecov
 
 deploy:
-  skip_cleanup: true
   - provider: script
     script: ci.sh publish=true
+    skip_cleanup: true
     on:
       tags: true
 

--- a/ci.sh
+++ b/ci.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 set -e
 
-# Please run it from root project directory
+# You can run it from any directory.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_DIR="$DIR"
+
+pushd "$PROJECT_DIR"
+
+# Pass "publish=true" as first argument to initiate release process.
+SHOULD_PUBLISH_RELEASE="$1"
 
 # For some reason test for annotation processor are failing on a regular CI setup.
 # So we had to exclude test task for it from the main build process and execute it as a separate command.
@@ -9,8 +16,8 @@ set -e
 ./gradlew :storio-sqlite-annotations-processor-test:testDebugUnitTest
 ./gradlew :storio-content-resolver-annotations-processor-test:testDebugUnitTest
 
-if git describe --exact-match --tags $(git log -n1 --pretty='%h') ; then
-    echo "Git tag detected, launching release process..."
+if [ "$SHOULD_PUBLISH_RELEASE" == "publish=true" ]; then
+    echo "Launching release publishing process..."
 
     if [ -z "$GPG_SECRET_KEYS" ]; then
         echo "Put base64 encoded gpg secret key for signing into GPG_SECRET_KEYS env variable."


### PR DESCRIPTION
Continuation of #806, as far as I understand Travis doesn't run build if you just push a tag unless you add a deploy section, so I did that.

We can try to release 2.0.1 by tag as an experiment :)

See:

- https://docs.travis-ci.com/user/deployment
- https://docs.travis-ci.com/user/deployment/script/