### PR TITLE
Fix build signing after update to Gradle 4.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,10 +200,6 @@ allprojects {
 
 ext.VERSION_NAME = projectVersion()
 
-def isReleaseBuild() {
-    return !projectVersion().equals('development')
-}
-
 def getReleaseRepositoryUrl() {
     return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
             : 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'

--- a/build.gradle
+++ b/build.gradle
@@ -179,6 +179,19 @@ def validateTagAndVersion() {
     if (projectVersion().isEmpty()) {
         throw new IllegalStateException('Publishing is not allowed because current projectVersion is empty')
     }
+
+    if ('development'.equals(projectVersion())) {
+        throw new IllegalStateException('Publishing is not allowed because current projectVersion is "development"')
+    }
+}
+
+def isValidReleaseState() {
+    try {
+        validateTagAndVersion()
+        return true
+    } catch (Exception e) {
+        return false
+    }
 }
 
 allprojects {

--- a/gradle/publish-android-lib.gradle
+++ b/gradle/publish-android-lib.gradle
@@ -89,7 +89,7 @@ afterEvaluate { project ->
     }
 
     signing {
-        required { isReleaseBuild() && gradle.taskGraph.hasTask('uploadArchives') }
+        required { isValidReleaseState() }
         sign configurations.archives
     }
 

--- a/gradle/publish-java-lib.gradle
+++ b/gradle/publish-java-lib.gradle
@@ -74,7 +74,7 @@ afterEvaluate { project ->
     }
 
     signing {
-        required { isReleaseBuild() && gradle.taskGraph.hasTask('uploadArchives') }
+        required { isValidReleaseState() }
         sign configurations.archives
     }
 


### PR DESCRIPTION
Auto release of 2.0.1 failed because build process didn't sign jars, sign task was skipped.

My guess is that Gradle 4.x significantly refactored build lifecycle and we can't analyze task graph at the time of deciding if we should sign jars or not.

I've checked new version locally, it runs signing, so it should be good now, I'll release v2.0.2 after merging this PR.