### PR TITLE
Disable debug builds for library modules.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,6 +146,17 @@ subprojects {
                 }
             }
         }
+
+        // Ignore 'debug' buildType for library projects
+        // Because we don't have debug-specific code and we don't need to build debug variants
+        // https://gist.github.com/artem-zinnatullin/ec3bce6dcb2cd524c435
+        if ('com.android.build.gradle.LibraryPlugin'.equals(plugin.class.name)) {
+            project.android.variantFilter {
+                if (it.buildType.name.equals('debug')) {
+                    it.ignore = true
+                }
+            }
+        }
     }
 }
 

--- a/ci.sh
+++ b/ci.sh
@@ -12,9 +12,9 @@ SHOULD_PUBLISH_RELEASE="$1"
 
 # For some reason test for annotation processor are failing on a regular CI setup.
 # So we had to exclude test task for it from the main build process and execute it as a separate command.
-./gradlew clean build checkstyle -PdisablePreDex -x :storio-sqlite-annotations-processor-test:test -x :storio-content-resolver-annotations-processor-test:test
-./gradlew :storio-sqlite-annotations-processor-test:testDebugUnitTest
-./gradlew :storio-content-resolver-annotations-processor-test:testDebugUnitTest
+./gradlew clean build checkstyle -PdisablePreDex --exclude-task :storio-sqlite-annotations-processor-test:test --exclude-task :storio-content-resolver-annotations-processor-test:test
+./gradlew :storio-sqlite-annotations-processor-test:test
+./gradlew :storio-content-resolver-annotations-processor-test:test
 
 if [ "$SHOULD_PUBLISH_RELEASE" == "publish=true" ]; then
     echo "Launching release publishing process..."

--- a/gradle/jacoco-android.gradle
+++ b/gradle/jacoco-android.gradle
@@ -14,7 +14,9 @@ jacoco {
 
 project.afterEvaluate {
     // Grab all build types and product flavors
-    def buildTypes = android.buildTypes.collect { type -> type.name }
+    def buildTypes = android.buildTypes
+            .collect { type -> type.name }
+            .findAll { buildTypeName -> 'debug'.equals(buildTypeName) == false  } // Ideally we should scan for non ignored build variants.
     def productFlavors = android.productFlavors.collect { flavor -> flavor.name }
 
     // When no product flavors defined, use empty


### PR DESCRIPTION
Closes #831, but doesn't solve possible Jacoco call leaks to release artifacts