### PR TITLE
Use environment variable to detect publishing state.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ after_success:
 
 deploy:
   - provider: script
-    script: ./ci.sh publish=true
+    script: PUBLISH_RELEASE=true ./ci.sh
     skip_cleanup: true
     on:
       tags: true

--- a/build.gradle
+++ b/build.gradle
@@ -186,6 +186,10 @@ def validateTagAndVersion() {
 }
 
 def isValidReleaseState() {
+    if ('true' != System.getenv('PUBLISH_RELEASE')) {
+        return false
+    }
+
     try {
         validateTagAndVersion()
         return true

--- a/ci.sh
+++ b/ci.sh
@@ -7,16 +7,14 @@ PROJECT_DIR="$DIR"
 
 pushd "$PROJECT_DIR"
 
-# Pass "publish=true" as first argument to initiate release process.
-SHOULD_PUBLISH_RELEASE="$1"
-
 # For some reason test for annotation processor are failing on a regular CI setup.
 # So we had to exclude test task for it from the main build process and execute it as a separate command.
 ./gradlew clean build checkstyle -PdisablePreDex -x :storio-sqlite-annotations-processor-test:test -x :storio-content-resolver-annotations-processor-test:test
 ./gradlew :storio-sqlite-annotations-processor-test:testDebugUnitTest
 ./gradlew :storio-content-resolver-annotations-processor-test:testDebugUnitTest
 
-if [ "$SHOULD_PUBLISH_RELEASE" == "publish=true" ]; then
+# Export "PUBLISH_RELEASE=true" to initiate release process.
+if [ "$PUBLISH_RELEASE" == "true" ]; then
     echo "Launching release publishing process..."
 
     if [ -z "$GPG_SECRET_KEYS" ]; then


### PR DESCRIPTION
Uhh damn Gradle, Travis and everything.

I wasn't able to use Gradle task graph analysis, so one way is to use env variable as I do here, another way is to always try to read release-related env variables for signing but I do find it more error prone and hard to debug in case if something will go wrong, current process will break build asap which is easier to debug

Sorry for so many PRs, but it's hard to test locally because CI has pretty different setup