### PR TITLE
Configure all signing params for automated release.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,10 +209,6 @@ def isValidReleaseState() {
     }
 }
 
-allprojects {
-    ext.'signing.password' = System.getenv('GPG_PASSPHRASE')
-}
-
 ext.VERSION_NAME = projectVersion()
 
 def getReleaseRepositoryUrl() {


### PR DESCRIPTION
Ok, I've double-checked everything locally (no daemons, no properties, etc), but on macOS. 

Turned out that even `signing.secretKeyRingFile` is required, I thought signing plugin can figure this automatically…