### PR TITLE
Override Travis install step to avoid unnecessary './gradlew assemble'.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ before_install:
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"extras;android;m2repository"'
   - eval $ANDROID_SDK_INSTALL_COMPONENT '"extras;google;m2repository"'
 
+install:
+  - echo "Override default Travis install step to avoid unnecessary './gradlew assemble'."
+
 script:
   - ./ci.sh
   


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/8667 for details, this will speedup all CI builds!