### PR TITLE
Support io.reactivex.Maybe

### DIFF
--- a/storio-common/src/main/java/com/pushtorefresh/storio2/operations/PreparedCompletableOperation.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio2/operations/PreparedCompletableOperation.java
@@ -6,11 +6,11 @@ import android.support.annotation.NonNull;
 import io.reactivex.Completable;
 
 /**
- * Common API of prepared write operations
+ * Common API of prepared operations with {@link Completable} support
  *
  * @param <Result> type of result
  */
-public interface PreparedWriteOperation<Result, Data> extends PreparedOperation<Result, Result, Data> {
+public interface PreparedCompletableOperation<Result, Data> extends PreparedOperation<Result, Result, Data> {
 
     @NonNull
     @CheckResult

--- a/storio-common/src/main/java/com/pushtorefresh/storio2/operations/PreparedMaybeOperation.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio2/operations/PreparedMaybeOperation.java
@@ -1,0 +1,17 @@
+package com.pushtorefresh.storio2.operations;
+
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+import io.reactivex.Maybe;
+
+/**
+ * Common API of prepared operations with {@link Maybe} support
+ *
+ * @param <Result> type of result
+ */
+public interface PreparedMaybeOperation<Result, WrappedResult, Data> extends PreparedOperation<Result, WrappedResult, Data> {
+
+    @NonNull
+    @CheckResult
+    Maybe<Result> asRxMaybe();
+}

--- a/storio-common/src/main/java/com/pushtorefresh/storio2/operations/internal/MaybeOnSubscribeExecuteAsBlocking.java
+++ b/storio-common/src/main/java/com/pushtorefresh/storio2/operations/internal/MaybeOnSubscribeExecuteAsBlocking.java
@@ -1,0 +1,36 @@
+package com.pushtorefresh.storio2.operations.internal;
+
+import android.support.annotation.NonNull;
+import com.pushtorefresh.storio2.operations.PreparedMaybeOperation;
+import io.reactivex.MaybeEmitter;
+import io.reactivex.MaybeOnSubscribe;
+
+/**
+ * Required to avoid problems with ClassLoader when RxJava is not in ClassPath
+ * We can not use anonymous classes from RxJava directly in StorIO, ClassLoader won't be happy :(
+ * <p>
+ * For internal usage only!
+ */
+public final class MaybeOnSubscribeExecuteAsBlocking<Result, WrappedResult, Data> implements MaybeOnSubscribe<Result> {
+
+    @NonNull
+    private final PreparedMaybeOperation<Result, WrappedResult, Data> preparedOperation;
+
+    public MaybeOnSubscribeExecuteAsBlocking(@NonNull PreparedMaybeOperation<Result, WrappedResult, Data> preparedOperation) {
+        this.preparedOperation = preparedOperation;
+    }
+
+    @Override
+    public void subscribe(MaybeEmitter<Result> emitter) throws Exception {
+        try {
+            final Result value = preparedOperation.executeAsBlocking();
+            if (value != null) {
+                emitter.onSuccess(value);
+            } else {
+                emitter.onComplete();
+            }
+        } catch (Exception e) {
+            emitter.onError(e);
+        }
+    }
+}

--- a/storio-common/src/test/java/com/pushtorefresh/storio2/operations/internal/CompletableOnSubscribeExecuteAsBlockingTest.java
+++ b/storio-common/src/test/java/com/pushtorefresh/storio2/operations/internal/CompletableOnSubscribeExecuteAsBlockingTest.java
@@ -1,7 +1,7 @@
 package com.pushtorefresh.storio2.operations.internal;
 
 import com.pushtorefresh.storio2.StorIOException;
-import com.pushtorefresh.storio2.operations.PreparedWriteOperation;
+import com.pushtorefresh.storio2.operations.PreparedCompletableOperation;
 
 import org.junit.Test;
 
@@ -21,7 +21,7 @@ public class CompletableOnSubscribeExecuteAsBlockingTest {
     @SuppressWarnings("ResourceType")
     @Test
     public void shouldExecuteAsBlockingAfterSubscription() {
-        final PreparedWriteOperation preparedOperation = mock(PreparedWriteOperation.class);
+        final PreparedCompletableOperation preparedOperation = mock(PreparedCompletableOperation.class);
 
         TestObserver testObserver = new TestObserver();
 
@@ -45,7 +45,7 @@ public class CompletableOnSubscribeExecuteAsBlockingTest {
     @SuppressWarnings({"ThrowableInstanceNeverThrown", "ResourceType"})
     @Test
     public void shouldCallOnErrorIfExceptionOccurred() {
-        final PreparedWriteOperation preparedOperation = mock(PreparedWriteOperation.class);
+        final PreparedCompletableOperation preparedOperation = mock(PreparedCompletableOperation.class);
 
         StorIOException expectedException = new StorIOException("test exception");
 

--- a/storio-common/src/test/java/com/pushtorefresh/storio2/operations/internal/MaybeOnSubscribeExecuteAsBlockingTest.java
+++ b/storio-common/src/test/java/com/pushtorefresh/storio2/operations/internal/MaybeOnSubscribeExecuteAsBlockingTest.java
@@ -1,0 +1,89 @@
+package com.pushtorefresh.storio2.operations.internal;
+
+import com.pushtorefresh.storio2.StorIOException;
+import com.pushtorefresh.storio2.operations.PreparedMaybeOperation;
+
+import org.junit.Test;
+
+import io.reactivex.Maybe;
+import io.reactivex.observers.TestObserver;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class MaybeOnSubscribeExecuteAsBlockingTest {
+
+    @SuppressWarnings("CheckResult")
+    @Test
+    public void shouldExecuteAsBlockingAfterSubscription() {
+        //noinspection unchecked
+        final PreparedMaybeOperation<String, String, String> preparedOperation = mock(PreparedMaybeOperation.class);
+        String expectedResult = "test";
+        when(preparedOperation.executeAsBlocking()).thenReturn(expectedResult);
+
+        TestObserver<String> testObserver = new TestObserver<String>();
+
+        verifyZeroInteractions(preparedOperation);
+
+        Maybe<String> maybe = Maybe.create(new MaybeOnSubscribeExecuteAsBlocking<String, String, String>(preparedOperation));
+
+        verifyZeroInteractions(preparedOperation);
+
+        maybe.subscribe(testObserver);
+
+        testObserver.assertValue(expectedResult);
+        testObserver.assertNoErrors();
+        testObserver.assertComplete();
+
+        verify(preparedOperation).executeAsBlocking();
+    }
+
+    @SuppressWarnings("CheckResult")
+    @Test
+    public void shouldCompleteIfNullOccurred() {
+        //noinspection unchecked
+        final PreparedMaybeOperation<String, String, String> preparedOperation = mock(PreparedMaybeOperation.class);
+        when(preparedOperation.executeAsBlocking()).thenReturn(null);
+
+        TestObserver<String> testObserver = new TestObserver<String>();
+
+        verifyZeroInteractions(preparedOperation);
+
+        Maybe<String> maybe = Maybe.create(new MaybeOnSubscribeExecuteAsBlocking<String, String, String>(preparedOperation));
+
+        verifyZeroInteractions(preparedOperation);
+
+        maybe.subscribe(testObserver);
+
+        testObserver.assertNoErrors();
+        testObserver.assertComplete();
+
+        verify(preparedOperation).executeAsBlocking();
+    }
+
+    @SuppressWarnings("CheckResult")
+    @Test
+    public void shouldCallOnErrorIfExceptionOccurred() {
+        //noinspection unchecked
+        final PreparedMaybeOperation<Object, Object, Object> preparedOperation = mock(PreparedMaybeOperation.class);
+
+        StorIOException expectedException = new StorIOException("test exception");
+
+        when(preparedOperation.executeAsBlocking()).thenThrow(expectedException);
+
+        TestObserver<Object> testObserver = new TestObserver<Object>();
+
+        Maybe<Object> maybe = Maybe.create(new MaybeOnSubscribeExecuteAsBlocking<Object, Object, Object>(preparedOperation));
+
+        verifyZeroInteractions(preparedOperation);
+
+        maybe.subscribe(testObserver);
+
+        testObserver.assertError(expectedException);
+        testObserver.assertNotComplete();
+
+        verify(preparedOperation).executeAsBlocking();
+    }
+}

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio2/contentresolver/StorIOContentResolver.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio2/contentresolver/StorIOContentResolver.java
@@ -16,6 +16,7 @@ import com.pushtorefresh.storio2.contentresolver.queries.InsertQuery;
 import com.pushtorefresh.storio2.contentresolver.queries.Query;
 import com.pushtorefresh.storio2.contentresolver.queries.UpdateQuery;
 
+import com.pushtorefresh.storio2.operations.PreparedCompletableOperation;
 import java.util.Collections;
 import java.util.Set;
 
@@ -97,7 +98,7 @@ public abstract class StorIOContentResolver {
      * @return the scheduler or {@code null} if it isn't needed to apply it.
      * @see com.pushtorefresh.storio2.operations.PreparedOperation#asRxFlowable(BackpressureStrategy)
      * @see com.pushtorefresh.storio2.operations.PreparedOperation#asRxSingle()
-     * @see com.pushtorefresh.storio2.operations.PreparedWriteOperation#asRxCompletable()
+     * @see PreparedCompletableOperation#asRxCompletable()
      */
     @Nullable
     public abstract Scheduler defaultRxScheduler();

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio2/contentresolver/impl/DefaultStorIOContentResolver.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio2/contentresolver/impl/DefaultStorIOContentResolver.java
@@ -22,6 +22,7 @@ import com.pushtorefresh.storio2.contentresolver.queries.Query;
 import com.pushtorefresh.storio2.contentresolver.queries.UpdateQuery;
 import com.pushtorefresh.storio2.internal.TypeMappingFinderImpl;
 
+import com.pushtorefresh.storio2.operations.PreparedCompletableOperation;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -210,7 +211,7 @@ public class DefaultStorIOContentResolver extends StorIOContentResolver {
          * <p/>
          * @see com.pushtorefresh.storio2.operations.PreparedOperation#asRxFlowable(BackpressureStrategy)
          * @see com.pushtorefresh.storio2.operations.PreparedOperation#asRxSingle()
-         * @see com.pushtorefresh.storio2.operations.PreparedWriteOperation#asRxCompletable()
+         * @see PreparedCompletableOperation#asRxCompletable()
          *
          * @return the scheduler or {@code null} if it isn't needed to apply it.
          */

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio2/contentresolver/operations/delete/PreparedDelete.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio2/contentresolver/operations/delete/PreparedDelete.java
@@ -4,7 +4,7 @@ import android.support.annotation.NonNull;
 
 import com.pushtorefresh.storio2.contentresolver.StorIOContentResolver;
 import com.pushtorefresh.storio2.contentresolver.queries.DeleteQuery;
-import com.pushtorefresh.storio2.operations.PreparedWriteOperation;
+import com.pushtorefresh.storio2.operations.PreparedCompletableOperation;
 
 import java.util.Collection;
 
@@ -15,7 +15,8 @@ import static com.pushtorefresh.storio2.internal.Checks.checkNotNull;
  *
  * @param <Result> type of result of Delete Operation.
  */
-public abstract class PreparedDelete<Result, Data> implements PreparedWriteOperation<Result, Data> {
+public abstract class PreparedDelete<Result, Data> implements
+    PreparedCompletableOperation<Result, Data> {
 
     @NonNull
     protected final StorIOContentResolver storIOContentResolver;

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio2/contentresolver/operations/get/PreparedGetObject.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio2/contentresolver/operations/get/PreparedGetObject.java
@@ -12,9 +12,11 @@ import com.pushtorefresh.storio2.contentresolver.ContentResolverTypeMapping;
 import com.pushtorefresh.storio2.contentresolver.StorIOContentResolver;
 import com.pushtorefresh.storio2.contentresolver.operations.internal.RxJavaUtils;
 import com.pushtorefresh.storio2.contentresolver.queries.Query;
+import com.pushtorefresh.storio2.operations.PreparedMaybeOperation;
 
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
+import io.reactivex.Maybe;
 import io.reactivex.Single;
 
 import static com.pushtorefresh.storio2.internal.Checks.checkNotNull;
@@ -26,7 +28,8 @@ import static com.pushtorefresh.storio2.internal.Checks.checkNotNull;
  *
  * @param <T> type of result.
  */
-public class PreparedGetObject<T> extends PreparedGet<T, Optional<T>> {
+public class PreparedGetObject<T> extends PreparedGet<T, Optional<T>> implements
+        PreparedMaybeOperation<T, Optional<T>, Query> {
 
     @NonNull
     private final Class<T> type;
@@ -135,6 +138,12 @@ public class PreparedGetObject<T> extends PreparedGet<T, Optional<T>> {
     @Override
     public Single<Optional<T>> asRxSingle() {
         return RxJavaUtils.createSingleOptional(storIOContentResolver, this);
+    }
+
+    @NonNull
+    @Override
+    public Maybe<T> asRxMaybe() {
+        return RxJavaUtils.createMaybe(storIOContentResolver, this);
     }
 
     /**

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio2/contentresolver/operations/internal/RxJavaUtils.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio2/contentresolver/operations/internal/RxJavaUtils.java
@@ -8,7 +8,7 @@ import com.pushtorefresh.storio2.contentresolver.Changes;
 import com.pushtorefresh.storio2.contentresolver.StorIOContentResolver;
 import com.pushtorefresh.storio2.contentresolver.queries.Query;
 import com.pushtorefresh.storio2.operations.PreparedOperation;
-import com.pushtorefresh.storio2.operations.PreparedWriteOperation;
+import com.pushtorefresh.storio2.operations.PreparedCompletableOperation;
 import com.pushtorefresh.storio2.operations.internal.CompletableOnSubscribeExecuteAsBlocking;
 import com.pushtorefresh.storio2.operations.internal.FlowableOnSubscribeExecuteAsBlocking;
 import com.pushtorefresh.storio2.operations.internal.FlowableOnSubscribeExecuteAsBlockingOptional;
@@ -128,7 +128,7 @@ public class RxJavaUtils {
     @NonNull
     public static <Result, Data> Completable createCompletable(
             @NonNull StorIOContentResolver storIOContentResolver,
-            @NonNull PreparedWriteOperation<Result, Data> operation
+            @NonNull PreparedCompletableOperation<Result, Data> operation
     ) {
         throwExceptionIfRxJava2IsNotAvailable("asRxCompletable()");
 

--- a/storio-content-resolver/src/main/java/com/pushtorefresh/storio2/contentresolver/operations/put/PreparedPut.java
+++ b/storio-content-resolver/src/main/java/com/pushtorefresh/storio2/contentresolver/operations/put/PreparedPut.java
@@ -4,7 +4,7 @@ import android.content.ContentValues;
 import android.support.annotation.NonNull;
 
 import com.pushtorefresh.storio2.contentresolver.StorIOContentResolver;
-import com.pushtorefresh.storio2.operations.PreparedWriteOperation;
+import com.pushtorefresh.storio2.operations.PreparedCompletableOperation;
 
 import java.util.Collection;
 
@@ -13,7 +13,8 @@ import java.util.Collection;
  * in {@link android.content.ContentProvider}.
  *
  */
-public abstract class PreparedPut<Result, Data> implements PreparedWriteOperation<Result, Data> {
+public abstract class PreparedPut<Result, Data> implements
+    PreparedCompletableOperation<Result, Data> {
 
     @NonNull
     protected final StorIOContentResolver storIOContentResolver;

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio2/contentresolver/design/GetOperationDesignTest.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio2/contentresolver/design/GetOperationDesignTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
+import io.reactivex.Maybe;
 import io.reactivex.Single;
 
 import static org.mockito.Mockito.mock;
@@ -135,5 +136,18 @@ public class GetOperationDesignTest extends OperationDesignTest {
                 .withGetResolver(ArticleMeta.GET_RESOLVER)
                 .prepare()
                 .asRxSingle();
+    }
+
+    @Test
+    public void getObjectAsMaybe() {
+        Maybe<Article> maybe = storIOContentResolver()
+                .get()
+                .object(Article.class)
+                .withQuery(Query.builder()
+                        .uri(mock(Uri.class))
+                        .build())
+                .withGetResolver(ArticleMeta.GET_RESOLVER)
+                .prepare()
+                .asRxMaybe();
     }
 }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio2/contentresolver/operations/SchedulerChecker.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio2/contentresolver/operations/SchedulerChecker.java
@@ -4,7 +4,7 @@ import android.support.annotation.NonNull;
 
 import com.pushtorefresh.storio2.contentresolver.StorIOContentResolver;
 import com.pushtorefresh.storio2.operations.PreparedOperation;
-import com.pushtorefresh.storio2.operations.PreparedWriteOperation;
+import com.pushtorefresh.storio2.operations.PreparedCompletableOperation;
 
 import org.mockito.Mockito;
 
@@ -44,7 +44,7 @@ public class SchedulerChecker {
         check(operation);
     }
 
-    public void checkAsCompletable(@NonNull PreparedWriteOperation operation) {
+    public void checkAsCompletable(@NonNull PreparedCompletableOperation operation) {
         operation.asRxCompletable().subscribe();
         check(operation);
     }

--- a/storio-content-resolver/src/test/java/com/pushtorefresh/storio2/contentresolver/operations/get/GetObjectStub.java
+++ b/storio-content-resolver/src/test/java/com/pushtorefresh/storio2/contentresolver/operations/get/GetObjectStub.java
@@ -14,6 +14,7 @@ import com.pushtorefresh.storio2.test.FlowableBehaviorChecker;
 
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
+import io.reactivex.Maybe;
 import io.reactivex.Single;
 import io.reactivex.functions.Consumer;
 
@@ -171,6 +172,21 @@ class GetObjectStub {
                 .testAction(new Consumer<Optional<TestItem>>() {
                     @Override
                     public void accept(@NonNull Optional<TestItem> testItem) throws Exception {
+                        verify(storIOContentResolver).defaultRxScheduler();
+                        verifyBehavior(testItem);
+                    }
+                })
+                .checkBehaviorOfFlowable();
+
+    }
+
+    void verifyBehavior(@NonNull Maybe<TestItem> maybe) {
+        new FlowableBehaviorChecker<TestItem>()
+                .flowable(maybe.toFlowable())
+                .expectedNumberOfEmissions(1)
+                .testAction(new Consumer<TestItem>() {
+                    @Override
+                    public void accept(@NonNull TestItem testItem) throws Exception {
                         verify(storIOContentResolver).defaultRxScheduler();
                         verifyBehavior(testItem);
                     }

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio2/sqlite/StorIOSQLite.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio2/sqlite/StorIOSQLite.java
@@ -7,6 +7,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
 
+import com.pushtorefresh.storio2.operations.PreparedCompletableOperation;
 import com.pushtorefresh.storio2.operations.PreparedOperation;
 import com.pushtorefresh.storio2.sqlite.operations.delete.PreparedDelete;
 import com.pushtorefresh.storio2.sqlite.operations.execute.PreparedExecuteSQL;
@@ -205,7 +206,7 @@ public abstract class StorIOSQLite implements Closeable {
      * @return the scheduler or {@code null} if it isn't needed to apply it.
      * @see PreparedOperation#asRxFlowable(BackpressureStrategy)
      * @see com.pushtorefresh.storio2.operations.PreparedOperation#asRxSingle()
-     * @see com.pushtorefresh.storio2.operations.PreparedWriteOperation#asRxCompletable()
+     * @see PreparedCompletableOperation#asRxCompletable()
      */
     @Nullable
     public abstract Scheduler defaultRxScheduler();

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio2/sqlite/impl/DefaultStorIOSQLite.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio2/sqlite/impl/DefaultStorIOSQLite.java
@@ -10,6 +10,7 @@ import android.support.annotation.WorkerThread;
 import com.pushtorefresh.storio2.TypeMappingFinder;
 import com.pushtorefresh.storio2.internal.ChangesBus;
 import com.pushtorefresh.storio2.internal.TypeMappingFinderImpl;
+import com.pushtorefresh.storio2.operations.PreparedCompletableOperation;
 import com.pushtorefresh.storio2.sqlite.Changes;
 import com.pushtorefresh.storio2.sqlite.Interceptor;
 import com.pushtorefresh.storio2.sqlite.SQLiteTypeMapping;
@@ -254,7 +255,7 @@ public class DefaultStorIOSQLite extends StorIOSQLite {
          * @return builder.
          * @see com.pushtorefresh.storio2.operations.PreparedOperation#asRxFlowable(BackpressureStrategy)
          * @see com.pushtorefresh.storio2.operations.PreparedOperation#asRxSingle()
-         * @see com.pushtorefresh.storio2.operations.PreparedWriteOperation#asRxCompletable()
+         * @see PreparedCompletableOperation#asRxCompletable()
          */
         @NonNull
         public CompleteBuilder defaultRxScheduler(@Nullable Scheduler defaultRxScheduler) {

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio2/sqlite/operations/delete/PreparedDelete.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio2/sqlite/operations/delete/PreparedDelete.java
@@ -3,7 +3,7 @@ package com.pushtorefresh.storio2.sqlite.operations.delete;
 import android.support.annotation.NonNull;
 import android.support.annotation.WorkerThread;
 
-import com.pushtorefresh.storio2.operations.PreparedWriteOperation;
+import com.pushtorefresh.storio2.operations.PreparedCompletableOperation;
 import com.pushtorefresh.storio2.sqlite.Interceptor;
 import com.pushtorefresh.storio2.sqlite.StorIOSQLite;
 import com.pushtorefresh.storio2.sqlite.queries.DeleteQuery;
@@ -17,7 +17,7 @@ import static com.pushtorefresh.storio2.sqlite.impl.ChainImpl.buildChain;
  *
  * @param <T> type of object to delete.
  */
-public abstract class PreparedDelete<T, Data> implements PreparedWriteOperation<T, Data> {
+public abstract class PreparedDelete<T, Data> implements PreparedCompletableOperation<T, Data> {
 
     @NonNull
     protected final StorIOSQLite storIOSQLite;

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio2/sqlite/operations/get/PreparedGetObject.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio2/sqlite/operations/get/PreparedGetObject.java
@@ -8,20 +8,24 @@ import android.support.annotation.Nullable;
 import com.pushtorefresh.storio2.Optional;
 import com.pushtorefresh.storio2.StorIOException;
 import com.pushtorefresh.storio2.operations.PreparedOperation;
+import com.pushtorefresh.storio2.operations.PreparedMaybeOperation;
 import com.pushtorefresh.storio2.sqlite.Interceptor;
 import com.pushtorefresh.storio2.sqlite.SQLiteTypeMapping;
 import com.pushtorefresh.storio2.sqlite.StorIOSQLite;
 import com.pushtorefresh.storio2.sqlite.operations.internal.RxJavaUtils;
+import com.pushtorefresh.storio2.sqlite.queries.GetQuery;
 import com.pushtorefresh.storio2.sqlite.queries.Query;
 import com.pushtorefresh.storio2.sqlite.queries.RawQuery;
 
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
+import io.reactivex.Maybe;
 import io.reactivex.Single;
 
 import static com.pushtorefresh.storio2.internal.Checks.checkNotNull;
 
-public class PreparedGetObject<T> extends PreparedGet<T, Optional<T>> {
+public class PreparedGetObject<T> extends PreparedGet<T, Optional<T>> implements
+    PreparedMaybeOperation<T, Optional<T>, GetQuery> {
 
     @NonNull
     private final Class<T> type;
@@ -88,6 +92,22 @@ public class PreparedGetObject<T> extends PreparedGet<T, Optional<T>> {
     @Override
     public Single<Optional<T>> asRxSingle() {
         return RxJavaUtils.createSingleOptional(storIOSQLite, this);
+    }
+
+    /**
+     * Creates {@link Maybe} which will perform Get Operation lazily when somebody subscribes to it and send result to observer.
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>Operates on {@link StorIOSQLite#defaultRxScheduler()} if not {@code null}.</dd>
+     * </dl>
+     *
+     * @return non-null {@link Maybe} which will perform Get Operation.
+     * And send result to observer.
+     */
+    @NonNull
+    @Override
+    public Maybe<T> asRxMaybe() {
+        return RxJavaUtils.createMaybe(storIOSQLite, this);
     }
 
     @NonNull

--- a/storio-sqlite/src/main/java/com/pushtorefresh/storio2/sqlite/operations/put/PreparedPut.java
+++ b/storio-sqlite/src/main/java/com/pushtorefresh/storio2/sqlite/operations/put/PreparedPut.java
@@ -4,7 +4,7 @@ import android.content.ContentValues;
 import android.support.annotation.NonNull;
 import android.support.annotation.WorkerThread;
 
-import com.pushtorefresh.storio2.operations.PreparedWriteOperation;
+import com.pushtorefresh.storio2.operations.PreparedCompletableOperation;
 import com.pushtorefresh.storio2.sqlite.Interceptor;
 import com.pushtorefresh.storio2.sqlite.StorIOSQLite;
 
@@ -17,7 +17,8 @@ import static com.pushtorefresh.storio2.sqlite.impl.ChainImpl.buildChain;
  * Prepared Put Operation for {@link StorIOSQLite} which performs insert or update data
  * in {@link StorIOSQLite}.
  */
-public abstract class PreparedPut<Result, Data> implements PreparedWriteOperation<Result, Data> {
+public abstract class PreparedPut<Result, Data> implements
+    PreparedCompletableOperation<Result, Data> {
 
     @NonNull
     protected final StorIOSQLite storIOSQLite;

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/design/GetOperationDesignTest.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/design/GetOperationDesignTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import java.util.List;
 
 import io.reactivex.Flowable;
+import io.reactivex.Maybe;
 import io.reactivex.Single;
 
 import static io.reactivex.BackpressureStrategy.LATEST;
@@ -257,5 +258,34 @@ public class GetOperationDesignTest extends OperationDesignTest {
                         .build())
                 .prepare()
                 .asRxSingle();
+    }
+
+    @Test
+    public void getObjectMaybe() {
+        Maybe<User> maybeUser = storIOSQLite()
+                .get()
+                .object(User.class)
+                .withQuery(Query.builder()
+                        .table("users")
+                        .where("email = ?")
+                        .whereArgs("artem.zinnatullin@gmail.com")
+                        .build())
+                .withGetResolver(UserTableMeta.GET_RESOLVER)
+                .prepare()
+                .asRxMaybe();
+    }
+
+    @Test
+    public void getObjectWithRawQueryMaybe() {
+        Maybe<User> maybeUser = storIOSQLite()
+                .get()
+                .object(User.class)
+                .withQuery(RawQuery.builder()
+                        .query("SELECT FROM bla_bla join on bla_bla_bla WHERE x = ?")
+                        .args("arg1", "arg2")
+                        .build())
+                .withGetResolver(UserTableMeta.GET_RESOLVER)
+                .prepare()
+                .asRxMaybe();
     }
 }

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/operations/SchedulerChecker.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/operations/SchedulerChecker.java
@@ -3,7 +3,7 @@ package com.pushtorefresh.storio2.sqlite.operations;
 import android.support.annotation.NonNull;
 
 import com.pushtorefresh.storio2.operations.PreparedOperation;
-import com.pushtorefresh.storio2.operations.PreparedWriteOperation;
+import com.pushtorefresh.storio2.operations.PreparedCompletableOperation;
 import com.pushtorefresh.storio2.sqlite.StorIOSQLite;
 
 import io.reactivex.schedulers.TestScheduler;
@@ -43,7 +43,7 @@ public class SchedulerChecker {
         check(operation);
     }
 
-    public void checkAsCompletable(@NonNull PreparedWriteOperation operation) {
+    public void checkAsCompletable(@NonNull PreparedCompletableOperation operation) {
         operation.asRxCompletable().subscribe();
         check(operation);
     }

--- a/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/operations/get/GetObjectStub.java
+++ b/storio-sqlite/src/test/java/com/pushtorefresh/storio2/sqlite/operations/get/GetObjectStub.java
@@ -17,6 +17,7 @@ import org.mockito.stubbing.Answer;
 
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
+import io.reactivex.Maybe;
 import io.reactivex.Single;
 import io.reactivex.functions.Consumer;
 
@@ -193,6 +194,20 @@ class GetObjectStub {
                 .checkBehaviorOfFlowable();
     }
 
+    void verifyQueryBehavior(@NonNull Maybe<TestItem> maybe) {
+        new FlowableBehaviorChecker<TestItem>()
+                .flowable(maybe.toFlowable())
+                .expectedNumberOfEmissions(1)
+                .testAction(new Consumer<TestItem>() {
+                    @Override
+                    public void accept(@NonNull TestItem testItem) {
+                        verify(storIOSQLite).defaultRxScheduler();
+                        verifyQueryBehavior(testItem);
+                    }
+                })
+                .checkBehaviorOfFlowable();
+    }
+
     void verifyQueryBehavior(@NonNull Single<Optional<TestItem>> single) {
         new FlowableBehaviorChecker<Optional<TestItem>>()
                 .flowable(single.toFlowable())
@@ -244,6 +259,21 @@ class GetObjectStub {
                     @Override
                     public void accept(@NonNull Optional<TestItem> testItem) {
                        verifyRawQueryBehavior(testItem);
+                    }
+                })
+                .checkBehaviorOfFlowable();
+
+        assertThat(rawQuery.observesTables()).isNotNull();
+    }
+
+    void verifyRawQueryBehavior(@NonNull Maybe<TestItem> maybe) {
+        new FlowableBehaviorChecker<TestItem>()
+                .flowable(maybe.toFlowable())
+                .expectedNumberOfEmissions(1)
+                .testAction(new Consumer<TestItem>() {
+                    @Override
+                    public void accept(@NonNull TestItem testItem) {
+                        verifyRawQueryBehavior(testItem);
                     }
                 })
                 .checkBehaviorOfFlowable();


### PR DESCRIPTION
https://github.com/pushtorefresh/storio/issues/846
https://github.com/pushtorefresh/storio/issues/855

I've added Maybe support only to `PreparedGetObject`. After some thoughts, I came to a conclusion that it doesn't really make much sense to have it for other queries. Maybe is some kind of a reactive optional and in case of `List`, `Cursor` and `NumberOfResults` queries we always have a valid result for empty cases so I don't see any value in wrapping them into `Maybe`.