### PR TITLE
Update Gradle Nexus plugin 0.8.0 → 0.11.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // Automatic releases to Sonatype.
-        classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.8.0'
+        classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0'
 
         classpath 'com.squareup.sqldelight:gradle-plugin:0.6.1'
 


### PR DESCRIPTION
Our 3.0.0 maven central upload silently failed (with "BUILD SUCCESSFUL") https://api.travis-ci.org/v3/job/319123247/log.txt

I hope Gradle Nexus Plugin 0.11.0 will fix the issue as changelog says it brings support for Gradle 4.1.

https://github.com/Codearte/gradle-nexus-staging-plugin/releases